### PR TITLE
Add sbol-diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ The `sbol-expand-derivations` utility searches through an SBOL file for Combinat
 ### Calculate sequences of DNA components in an SBOL file
 
 The `sbol-calculate-sequences` utility attempts to calculate the sequence of any DNA Component that can be fully specified from the sequences of its sub-components.
+
+### Compute the difference between two SBOL3 documents
+The `sbol-diff` utility computes the difference between two SBOL3 documents
+and reports the differences.

--- a/sbol_utilities/sbol_diff.py
+++ b/sbol_utilities/sbol_diff.py
@@ -8,30 +8,6 @@ from typing import Union, Tuple, Optional, Sequence
 import rdflib.compare
 
 
-def init_logging(debug=False):
-    msg_format = "%(asctime)s.%(msecs)03dZ:%(levelname)s:%(message)s"
-    date_format = "%Y-%m-%dT%H:%M:%S"
-    level = logging.INFO
-    if debug:
-        level = logging.DEBUG
-    logging.basicConfig(format=msg_format, datefmt=date_format, level=level)
-    logging.Formatter.converter = time.gmtime
-
-
-def parse_args(args: Optional[Sequence[str]] = None):
-    parser = argparse.ArgumentParser()
-    parser.add_argument('file1', metavar='FILE1',
-                        help='First Input File')
-    parser.add_argument('file2', metavar='FILE2',
-                        help='Second Input File')
-    parser.add_argument('-s', '--silent', action='store_true',
-                        help='Generate no output, only status')
-    parser.add_argument('--debug', action='store_true',
-                        help='Enable debug logging (default: disabled)')
-    args = parser.parse_args(args)
-    return args
-
-
 def load_rdf(fpath: Union[str, bytes, os.PathLike]) -> rdflib.Graph:
     rdf_format = rdflib.util.guess_format(fpath)
     graph1 = rdflib.Graph()
@@ -74,6 +50,30 @@ def sbol_diff(fpath1: str, fpath2: str, silent: bool = False) -> int:
         if not silent:
             report_diffs(fpath1, in1, fpath2, in2)
         return 1
+
+
+def init_logging(debug=False):
+    msg_format = "%(asctime)s.%(msecs)03dZ:%(levelname)s:%(message)s"
+    date_format = "%Y-%m-%dT%H:%M:%S"
+    level = logging.INFO
+    if debug:
+        level = logging.DEBUG
+    logging.basicConfig(format=msg_format, datefmt=date_format, level=level)
+    logging.Formatter.converter = time.gmtime
+
+
+def parse_args(args: Optional[Sequence[str]] = None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file1', metavar='FILE1',
+                        help='First Input File')
+    parser.add_argument('file2', metavar='FILE2',
+                        help='Second Input File')
+    parser.add_argument('-s', '--silent', action='store_true',
+                        help='Generate no output, only status')
+    parser.add_argument('--debug', action='store_true',
+                        help='Enable debug logging (default: disabled)')
+    args = parser.parse_args(args)
+    return args
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:

--- a/sbol_utilities/sbol_diff.py
+++ b/sbol_utilities/sbol_diff.py
@@ -1,0 +1,84 @@
+import argparse
+import logging
+import os
+import sys
+import time
+from typing import Union, Tuple
+
+import rdflib.compare
+
+
+def init_logging(debug=False):
+    msg_format = "%(asctime)s.%(msecs)03dZ:%(levelname)s:%(message)s"
+    date_format = "%Y-%m-%dT%H:%M:%S"
+    level = logging.INFO
+    if debug:
+        level = logging.DEBUG
+    logging.basicConfig(format=msg_format, datefmt=date_format, level=level)
+    logging.Formatter.converter = time.gmtime
+
+
+def parse_args(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file1', metavar='FILE1',
+                        help='First Input File')
+    parser.add_argument('file2', metavar='FILE2',
+                        help='Second Input File')
+    parser.add_argument('-s', '--silent', action='store_true',
+                        help='Generate no output, only status')
+    parser.add_argument('--debug', action='store_true',
+                        help='Enable debug logging (default: disabled)')
+    args = parser.parse_args(args)
+    return args
+
+
+def load_rdf(fpath: Union[str, bytes, os.PathLike]) -> rdflib.Graph:
+    rdf_format = rdflib.util.guess_format(fpath)
+    graph1 = rdflib.Graph()
+    graph1.parse(fpath, format=rdf_format)
+    return graph1
+
+
+def diff_rdf(g1: rdflib.Graph, g2: rdflib.Graph) -> Tuple[rdflib.Graph, rdflib.Graph, rdflib.Graph]:
+    iso1 = rdflib.compare.to_isomorphic(g1)
+    iso2 = rdflib.compare.to_isomorphic(g2)
+    rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
+    return rdf_diff
+
+
+def report_triples(header, graph):
+    print(header)
+    for s, p, o in graph:
+        print(f'\t{s}, {p}, {o}')
+
+
+def report_diffs(fpath1: str, in1: rdflib.Graph,
+                 fpath2: str, in2: rdflib.Graph) -> None:
+    if in1:
+        header = f'Triples in {fpath1}, not in {fpath2}:'
+        report_triples(header, in1)
+    if in2:
+        header = f'Triples in {fpath2}, not in {fpath1}:'
+        report_triples(header, in2)
+
+
+def sbol_diff(fpath1: str, fpath2: str, silent=False) -> int:
+    sbol1 = load_rdf(fpath1)
+    sbol2 = load_rdf(fpath2)
+    _, in1, in2 = diff_rdf(sbol1, sbol2)
+    if not in1 and not in2:
+        return 0
+    else:
+        if not silent:
+            report_diffs(fpath1, in1, fpath2, in2)
+        return 1
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    init_logging(args.debug)
+    return sbol_diff(args.file1, args.file2, silent=args.silent)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/sbol_utilities/sbol_diff.py
+++ b/sbol_utilities/sbol_diff.py
@@ -6,23 +6,24 @@ import time
 from typing import Union, Tuple, Optional, Sequence
 
 import rdflib.compare
+import sbol3
 
 
-def load_rdf(fpath: Union[str, bytes, os.PathLike]) -> rdflib.Graph:
+def _load_rdf(fpath: Union[str, bytes, os.PathLike]) -> rdflib.Graph:
     rdf_format = rdflib.util.guess_format(fpath)
     graph1 = rdflib.Graph()
     graph1.parse(fpath, format=rdf_format)
     return graph1
 
 
-def diff_rdf(g1: rdflib.Graph, g2: rdflib.Graph) -> Tuple[rdflib.Graph, rdflib.Graph, rdflib.Graph]:
+def _diff_graphs(g1: rdflib.Graph, g2: rdflib.Graph) -> Tuple[rdflib.Graph, rdflib.Graph, rdflib.Graph]:
     iso1 = rdflib.compare.to_isomorphic(g1)
     iso2 = rdflib.compare.to_isomorphic(g2)
     rdf_diff = rdflib.compare.graph_diff(iso1, iso2)
     return rdf_diff
 
 
-def report_triples(header: Optional[str], graph: rdflib.Graph) -> None:
+def _report_triples(header: Optional[str], graph: rdflib.Graph) -> None:
     if header:
         print(header)
     for s, p, o in graph:
@@ -30,29 +31,55 @@ def report_triples(header: Optional[str], graph: rdflib.Graph) -> None:
     return None
 
 
-def report_diffs(fpath1: str, in1: rdflib.Graph,
-                 fpath2: str, in2: rdflib.Graph) -> None:
+def _report_diffs(desc1: str, in1: rdflib.Graph,
+                  desc2: str, in2: rdflib.Graph) -> None:
     if in1:
-        header = f'Triples in {fpath1}, not in {fpath2}:'
-        report_triples(header, in1)
+        header = f'Triples in {desc1}, not in {desc2}:'
+        _report_triples(header, in1)
     if in2:
-        header = f'Triples in {fpath2}, not in {fpath1}:'
-        report_triples(header, in2)
+        header = f'Triples in {desc2}, not in {desc1}:'
+        _report_triples(header, in2)
 
 
-def sbol_diff(fpath1: str, fpath2: str, silent: bool = False) -> int:
-    sbol1 = load_rdf(fpath1)
-    sbol2 = load_rdf(fpath2)
-    _, in1, in2 = diff_rdf(sbol1, sbol2)
+def _diff_rdf(desc1: str, g1: rdflib.Graph, desc2: str, g2: rdflib.Graph,
+              silent: bool = False) -> int:
+    _, in1, in2 = _diff_graphs(g1, g2)
     if not in1 and not in2:
         return 0
     else:
         if not silent:
-            report_diffs(fpath1, in1, fpath2, in2)
+            _report_diffs(desc1, in1, desc2, in2)
         return 1
 
 
-def init_logging(debug=False):
+def file_diff(fpath1: str, fpath2: str, silent: bool = False) -> int:
+    """
+    Compute and report the difference between two SBOL3 files
+
+    :param fpath1: path to the first SBOL3 file
+    :param fpath2: path to the second SBOL3 file
+    :param silent: whether to report differences to stdout
+    :return: 1 if there are differences, 0 if they are the same
+    """
+    return _diff_rdf(fpath1, _load_rdf(fpath1), fpath2, _load_rdf(fpath2),
+                     silent=silent)
+
+
+def doc_diff(doc1: sbol3.Document, doc2: sbol3.Document,
+             silent: bool = False) -> int:
+    """
+    Compute and report the difference between two SBOL3 documents
+
+    :param doc1: the first SBOL3 document
+    :param doc2: the second SBOL3 document
+    :param silent: whether to report differences to stdout
+    :return: 1 if there are differences, 0 if they are the same
+    """
+    return _diff_rdf('Document 1', doc1.graph(), 'Document 2', doc2.graph(),
+                     silent=silent)
+
+
+def _init_logging(debug=False):
     msg_format = "%(asctime)s.%(msecs)03dZ:%(levelname)s:%(message)s"
     date_format = "%Y-%m-%dT%H:%M:%S"
     level = logging.INFO
@@ -62,7 +89,7 @@ def init_logging(debug=False):
     logging.Formatter.converter = time.gmtime
 
 
-def parse_args(args: Optional[Sequence[str]] = None):
+def _parse_args(args: Optional[Sequence[str]] = None):
     parser = argparse.ArgumentParser()
     parser.add_argument('file1', metavar='FILE1',
                         help='First Input File')
@@ -77,9 +104,15 @@ def parse_args(args: Optional[Sequence[str]] = None):
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
-    args = parse_args(argv)
-    init_logging(args.debug)
-    return sbol_diff(args.file1, args.file2, silent=args.silent)
+    """
+    Command line interface to sbol_diff
+
+    @param argv: command line arguments
+    @return: 1 if there are differences, 0 if they are the same
+    """
+    args = _parse_args(argv)
+    _init_logging(args.debug)
+    return file_diff(args.file1, args.file2, silent=args.silent)
 
 
 if __name__ == '__main__':

--- a/sbol_utilities/sbol_diff.py
+++ b/sbol_utilities/sbol_diff.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 import time
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional, Sequence
 
 import rdflib.compare
 
@@ -18,7 +18,7 @@ def init_logging(debug=False):
     logging.Formatter.converter = time.gmtime
 
 
-def parse_args(args=None):
+def parse_args(args: Optional[Sequence[str]] = None):
     parser = argparse.ArgumentParser()
     parser.add_argument('file1', metavar='FILE1',
                         help='First Input File')
@@ -46,10 +46,12 @@ def diff_rdf(g1: rdflib.Graph, g2: rdflib.Graph) -> Tuple[rdflib.Graph, rdflib.G
     return rdf_diff
 
 
-def report_triples(header, graph):
-    print(header)
+def report_triples(header: Optional[str], graph: rdflib.Graph) -> None:
+    if header:
+        print(header)
     for s, p, o in graph:
         print(f'\t{s}, {p}, {o}')
+    return None
 
 
 def report_diffs(fpath1: str, in1: rdflib.Graph,
@@ -62,7 +64,7 @@ def report_diffs(fpath1: str, in1: rdflib.Graph,
         report_triples(header, in2)
 
 
-def sbol_diff(fpath1: str, fpath2: str, silent=False) -> int:
+def sbol_diff(fpath1: str, fpath2: str, silent: bool = False) -> int:
     sbol1 = load_rdf(fpath1)
     sbol2 = load_rdf(fpath2)
     _, in1, in2 = diff_rdf(sbol1, sbol2)
@@ -74,7 +76,7 @@ def sbol_diff(fpath1: str, fpath2: str, silent=False) -> int:
         return 1
 
 
-def main(argv=None):
+def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parse_args(argv)
     init_logging(args.debug)
     return sbol_diff(args.file1, args.file2, silent=args.silent)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(name='sbol-utilities',
       entry_points = {
             'console_scripts': ['excel-to-sbol=sbol_utilities.excel_to_sbol:main',
                                 'sbol-expand-derivations=sbol_utilities.expand_combinatorial_derivations:main',
-                                'sbol-calculate-sequences=sbol_utilities.calculate_sequences:main']
+                                'sbol-calculate-sequences=sbol_utilities.calculate_sequences:main',
+                                'sbol-diff=sbol_utilities.sbol_diff:main']
       },
       packages=['sbol_utilities'],
       )

--- a/test/test_sbol_diff.py
+++ b/test/test_sbol_diff.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+import sbol_utilities.sbol_diff
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+TEST_FILES_DIR = os.path.join(TEST_DIR, 'test_files')
+SL_SBOL_PATH = os.path.join(TEST_FILES_DIR, 'simple_library.nt')
+ESL_SBOL_PATH = os.path.join(TEST_FILES_DIR, 'expanded_simple_library.nt')
+
+
+class TestSbolDiff(unittest.TestCase):
+
+    def test_command_line(self):
+        test_args = ['sbol_diff', ESL_SBOL_PATH, ESL_SBOL_PATH]
+        # Diff the same file, expecting no differences
+        with patch.object(sys, 'argv', test_args):
+            status = sbol_utilities.sbol_diff.main()
+        self.assertEqual(0, status)
+        # Diff two different files, use -s silent mode to prevent
+        # unsightly output to terminal
+        test_args = ['sbol_diff', '-s', ESL_SBOL_PATH, SL_SBOL_PATH]
+        with patch.object(sys, 'argv', test_args):
+            status = sbol_utilities.sbol_diff.main()
+        self.assertEqual(1, status)
+
+    def test_sbol_diff(self):
+        # Invoke sbol_utilities.sbol_diff.sbol_diff directly
+        actual = sbol_utilities.sbol_diff.sbol_diff(ESL_SBOL_PATH,
+                                                    ESL_SBOL_PATH,
+                                                    silent=True)
+        expected = 0
+        self.assertEqual(expected, actual)
+        actual = sbol_utilities.sbol_diff.sbol_diff(ESL_SBOL_PATH,
+                                                    SL_SBOL_PATH,
+                                                    silent=True)
+        expected = 1
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_sbol_diff.py
+++ b/test/test_sbol_diff.py
@@ -28,12 +28,12 @@ class TestSbolDiff(unittest.TestCase):
 
     def test_sbol_diff(self):
         # Invoke sbol_utilities.sbol_diff.sbol_diff directly
-        actual = sbol_utilities.sbol_diff.sbol_diff(ESL_SBOL_PATH,
+        actual = sbol_utilities.sbol_diff.file_diff(ESL_SBOL_PATH,
                                                     ESL_SBOL_PATH,
                                                     silent=True)
         expected = 0
         self.assertEqual(expected, actual)
-        actual = sbol_utilities.sbol_diff.sbol_diff(ESL_SBOL_PATH,
+        actual = sbol_utilities.sbol_diff.file_diff(ESL_SBOL_PATH,
                                                     SL_SBOL_PATH,
                                                     silent=True)
         expected = 1

--- a/test/test_sbol_diff.py
+++ b/test/test_sbol_diff.py
@@ -3,6 +3,8 @@ import sys
 import unittest
 from unittest.mock import patch
 
+import sbol3
+
 import sbol_utilities.sbol_diff
 
 TEST_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -26,8 +28,8 @@ class TestSbolDiff(unittest.TestCase):
             status = sbol_utilities.sbol_diff.main()
         self.assertEqual(1, status)
 
-    def test_sbol_diff(self):
-        # Invoke sbol_utilities.sbol_diff.sbol_diff directly
+    def test_file_diff(self):
+        # Invoke sbol_utilities.sbol_diff.file_diff directly
         actual = sbol_utilities.sbol_diff.file_diff(ESL_SBOL_PATH,
                                                     ESL_SBOL_PATH,
                                                     silent=True)
@@ -36,6 +38,21 @@ class TestSbolDiff(unittest.TestCase):
         actual = sbol_utilities.sbol_diff.file_diff(ESL_SBOL_PATH,
                                                     SL_SBOL_PATH,
                                                     silent=True)
+        expected = 1
+        self.assertEqual(expected, actual)
+
+    def test_doc_diff(self):
+        # Invoke sbol_utilities.sbol_diff.doc_diff directly
+        esl_doc = sbol3.Document()
+        esl_doc.read(ESL_SBOL_PATH)
+        sl_doc = sbol3.Document()
+        sl_doc.read(SL_SBOL_PATH)
+        actual = sbol_utilities.sbol_diff.doc_diff(esl_doc, esl_doc,
+                                                   silent=True)
+        expected = 0
+        self.assertEqual(expected, actual)
+        actual = sbol_utilities.sbol_diff.doc_diff(esl_doc, sl_doc,
+                                                   silent=True)
         expected = 1
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
Add a command line program to difference two SBOL files. Uses only RDF
differencing so it will work across RDF formats.