### PR TITLE
Make sure namespace is assigned correctly with FASTA conversion

### DIFF
--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -232,13 +232,16 @@ def convert_from_fasta(path: str, namespace: str, identity_map: Dict[str, str] =
         for r in SeqIO.parse(f, 'fasta'):
             if identity_map and r.id in identity_map:
                 identity = identity_map[r.id]
+                # TODO: consider whether non-default remappings of namespaces will be useful
+                namespace_to_use = None  # if we got an identity directly, let the namespace be inferred
             else:
                 identity = f'{namespace}/{sbol3.string_to_display_id(r.id)}'
+                namespace_to_use = namespace
             s = sbol3.Sequence(identity+'_sequence', name=r.name, description=r.description.strip(),
-                               elements=str(r.seq), encoding=sbol3.IUPAC_DNA_ENCODING, namespace=namespace)
+                               elements=str(r.seq), encoding=sbol3.IUPAC_DNA_ENCODING, namespace=namespace_to_use)
             doc.add(s)
             doc.add(sbol3.Component(identity, sbol3.SBO_DNA, name=r.name, description=r.description.strip(),
-                                    sequences=[s.identity], namespace=namespace))
+                                    sequences=[s.identity], namespace=namespace_to_use))
     return doc
 
 

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -135,6 +135,21 @@ class Test2To3Conversion(unittest.TestCase):
         comparison_doc.read(comparison_file)
         assert not doc_diff(doc3, comparison_doc), f'Converted FASTA file not identical to {comparison_file}'
 
+    def test_id_map_conversion_from_fasta(self):
+        """Test ability to convert from SBOL3 to FASTA"""
+        """Test ability to convert from GenBank to SBOL3"""
+        # Get the SBOL3 test document
+        tmp_sub = copy_to_tmp(package=['BBa_J23101.fasta'])
+        doc3 = convert_from_fasta(os.path.join(tmp_sub, 'BBa_J23101.fasta'), 'https://synbiohub.org/public/igem',
+                                  identity_map={'BBa_J23101': 'https://somewhere_else.org/public/igem/BBa_J23101'})
+
+        # Note: cannot directly round-trip because converter is lossy
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_fasta_altname.nt')
+        comparison_doc = sbol3.Document()
+        comparison_doc.read(comparison_file)
+        assert not doc_diff(doc3, comparison_doc), f'Converted FASTA file not identical to {comparison_file}'
+
     def test_commandline(self):
         test_files = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files')
         temp_name = tempfile.mkstemp()[1]

--- a/test/test_files/BBa_J23101_from_fasta_altname.nt
+++ b/test/test_files/BBa_J23101_from_fasta_altname.nt
@@ -1,0 +1,15 @@
+
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#description> "BBa_J23101 constitutive promoter family member" .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#displayId> "BBa_J23101" .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#hasNamespace> <https://somewhere_else.org/public/igem> .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#hasSequence> <https://somewhere_else.org/public/igem/BBa_J23101_sequence> .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#name> "BBa_J23101" .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<https://somewhere_else.org/public/igem/BBa_J23101> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#description> "BBa_J23101 constitutive promoter family member" .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#displayId> "BBa_J23101_sequence" .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#elements> "tttacagctagctcagtcctaggtattatgctagc" .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#encoding> <https://identifiers.org/edam:format_1207> .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#hasNamespace> <https://somewhere_else.org/public/igem> .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://sbols.org/v3#name> "BBa_J23101" .
+<https://somewhere_else.org/public/igem/BBa_J23101_sequence> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Sequence> .


### PR DESCRIPTION
Make sure namespace is assigned correctly with FASTA conversion when identities are remapped