### PR TITLE
Add autoapi reference page to docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,6 @@ sphinx:
 #    - pdf
 
 # Optionally declare the Python requirements required to build your docs
-# python:
-#    install:
-#  - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,11 +28,6 @@ author = 'To be added'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.napoleon',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.coverage',
-    'sphinx.ext.autosummary',
     'autoapi.extension',
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,19 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinx.ext.coverage',
+    'sphinx.ext.autosummary',
+    'autoapi.extension',
 ]
+
+# See https://sphinx-autoapi.readthedocs.io/en/latest/reference/config.html
+autoapi_dirs = ['../sbol_utilities']
+autoapi_options = ['members', 'undoc-members', 'show-inheritance',
+                   'show-module-summary', 'special-members']
+autoapi_python_class_content = 'both'
+autoapi_member_order = 'alphabetical'
+# If true, the current module name will be prepended to all description
+# unit titles (such as .. function::).
+add_module_names = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# these are fixed in accordance with rtd recommendations: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
+sphinx==4.4.0
+sphinx_rtd_theme==1.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 # these are fixed in accordance with rtd recommendations: https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#pinning-dependencies
 sphinx==4.4.0
 sphinx_rtd_theme==1.0.0
+sphinx-autoapi==1.8.4


### PR DESCRIPTION
Following discussion in #33, I had a look at the pySBOL3 code to see how read-the-docs is implemented there, and borrowed from that to use autoapi to set up a page on the docs "API Reference" that makes the docstrings of functions look nice. It looks like @tcmitchell set that up over there, so perhaps he would care to review this one? 

I can build the html ocally, but does give a lot of warnings e.g. 

`SBOL-utilities/docs/autoapi/sbol_utilities/component/index.rst:58: WARNING: Field list ends without a blank line; unexpected unindent.`

and 

`SBOL-utilities/docs/autoapi/index.rst: WARNING: document isn't included in any toctree`

I think these are just because autoapi is autogenerating the pages, but any wisdom about how to fix that, or to suppress the warnings if they aren't useful, would be great :) 