### PR TITLE
added fix for conversion between SBOL2 and SBOL3

### DIFF
--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -150,12 +150,11 @@ def convert2to3(sbol2_doc: Union[str, sbol2.Document], namespaces=None) -> sbol3
         sbol2.SBOL_ORIENTATION_INLINE: sbol3.SBOL_INLINE,
         sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT: sbol3.SBOL_REVERSE_COMPLEMENT
     }
-    def change_if_location(o):
+    def change_orientation(o):
         if isinstance(o, sbol3.Location):
-            if o.orientation in orientation_remapping:
+            if hasattr(o, 'orientation') and o.orientation in orientation_remapping:
                 o.orientation = orientation_remapping[o.orientation]
-    doc.traverse(change_if_location)
-
+    doc.traverse(change_orientation)
 
     return doc
 
@@ -192,11 +191,11 @@ def convert3to2(doc3: sbol3.Document) -> sbol2.Document:
         sbol3.SBOL_INLINE: sbol2.SBOL_ORIENTATION_INLINE,
         sbol3.SBOL_REVERSE_COMPLEMENT: sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT
     }
-    def change_location(o):
+    def change_orientation(o):
         if isinstance(o, sbol3.Location):
-            if o.orientation in orientation_remapping:
+            if hasattr(o, 'orientation') and o.orientation in orientation_remapping:
                 o.orientation = orientation_remapping[o.orientation]
-    doc3.traverse(change_location)
+    doc3.traverse(change_orientation)
 
     # Write to an RDF-XML temp file to run through the converter:
     sbol3_path = tempfile.mkstemp(suffix='.xml')[1]

--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -150,9 +150,11 @@ def convert2to3(sbol2_doc: Union[str, sbol2.Document], namespaces=None) -> sbol3
         sbol2.SBOL_ORIENTATION_INLINE: sbol3.SBOL_INLINE,
         sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT: sbol3.SBOL_REVERSE_COMPLEMENT
     }
-    for c in (o for o in doc.objects if isinstance(o, sbol3.Location)):
-        if c.orientation in orientation_remapping:
-            c.orientation = orientation_remapping[c.orientation]
+    def change_if_location(o):
+        if isinstance(o, sbol3.Location):
+            if o.orientation in orientation_remapping:
+                o.orientation = orientation_remapping[o.orientation]
+    doc.traverse(change_if_location)
 
 
     return doc
@@ -190,9 +192,11 @@ def convert3to2(doc3: sbol3.Document) -> sbol2.Document:
         sbol3.SBOL_INLINE: sbol2.SBOL_ORIENTATION_INLINE,
         sbol3.SBOL_REVERSE_COMPLEMENT: sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT
     }
-    for c in (o for o in doc3.objects if isinstance(o, sbol3.Location)):
-        if c.orientation in orientation_remapping:
-            c.orientation = orientation_remapping[c.orientation]
+    def change_location(o):
+        if isinstance(o, sbol3.Location):
+            if o.orientation in orientation_remapping:
+                o.orientation = orientation_remapping[o.orientation]
+    doc3.traverse(change_location)
 
     # Write to an RDF-XML temp file to run through the converter:
     sbol3_path = tempfile.mkstemp(suffix='.xml')[1]

--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -129,7 +129,7 @@ def convert2to3(sbol2_doc: Union[str, sbol2.Document], namespaces=None) -> sbol3
     encoding_remapping = {
         sbol2.SBOL_ENCODING_IUPAC: sbol3.IUPAC_DNA_ENCODING,
         sbol2.SBOL_ENCODING_IUPAC_PROTEIN: sbol3.IUPAC_PROTEIN_ENCODING,
-        sbol3.SMILES_ENCODING: sbol3.SMILES_ENCODING
+        sbol2.SBOL_ENCODING_SMILES: sbol3.SMILES_ENCODING
     }
     for s in (o for o in doc.objects if isinstance(o, sbol3.Sequence)):
         if s.encoding in encoding_remapping:
@@ -145,6 +145,16 @@ def convert2to3(sbol2_doc: Union[str, sbol2.Document], namespaces=None) -> sbol3
     for c in (o for o in doc.objects if isinstance(o, sbol3.Component)):
         c.types = [(type_remapping[t] if t in type_remapping else t) for t in c.types]
 
+    # remap orientation types
+    orientation_remapping = {
+        sbol2.SBOL_ORIENTATION_INLINE: sbol3.SBOL_INLINE,
+        sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT: sbol3.SBOL_REVERSE_COMPLEMENT
+    }
+    for c in (o for o in doc.objects if isinstance(o, sbol3.Location)):
+        if c.orientation in orientation_remapping:
+            c.orientation = orientation_remapping[c.orientation]
+
+
     return doc
 
 
@@ -159,7 +169,7 @@ def convert3to2(doc3: sbol3.Document) -> sbol2.Document:
     encoding_remapping = {
         sbol3.IUPAC_DNA_ENCODING: sbol2.SBOL_ENCODING_IUPAC,
         sbol3.IUPAC_PROTEIN_ENCODING: sbol2.SBOL_ENCODING_IUPAC_PROTEIN,
-        sbol3.SMILES_ENCODING: sbol3.SMILES_ENCODING
+        sbol3.SMILES_ENCODING: sbol2.SBOL_ENCODING_SMILES
     }
     for s in (o for o in doc3.objects if isinstance(o, sbol3.Sequence)):
         if s.encoding in encoding_remapping:
@@ -174,6 +184,15 @@ def convert3to2(doc3: sbol3.Document) -> sbol2.Document:
     }
     for c in (o for o in doc3.objects if isinstance(o, sbol3.Component)):
         c.types = [(type_remapping[t] if t in type_remapping else t) for t in c.types]
+
+    # remap orientation types
+    orientation_remapping = {
+        sbol3.SBOL_INLINE: sbol2.SBOL_ORIENTATION_INLINE,
+        sbol3.SBOL_REVERSE_COMPLEMENT: sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT
+    }
+    for c in (o for o in doc3.objects if isinstance(o, sbol3.Location)):
+        if c.orientation in orientation_remapping:
+            c.orientation = orientation_remapping[c.orientation]
 
     # Write to an RDF-XML temp file to run through the converter:
     sbol3_path = tempfile.mkstemp(suffix='.xml')[1]

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -62,6 +62,10 @@ class Test2To3Conversion(unittest.TestCase):
         assert doc2.componentDefinitions[0].sequences[0] == 'https://synbiohub.org/public/igem/BBa_J23101_sequence'
         assert doc2.sequences[0].encoding == 'http://www.chem.qmul.ac.uk/iubmb/misc/naseq.html'
         assert doc2.sequences[0].elements == 'tttacagctagctcagtcctaggtattatgctagc'
+        for c in doc2.componentDefinitions:
+            for sa in c.sequenceAnnotations:
+                for loc in sa.locations:
+                    assert loc.orientation != 'http://sbols.org/v3#inline'
 
     def test_genbank_conversion(self):
         """Test ability to convert from SBOL3 to GenBank"""

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -63,23 +63,33 @@ class Test2To3Conversion(unittest.TestCase):
         assert doc2.componentDefinitions[0].sequences[0] == 'https://synbiohub.org/public/igem/BBa_J23101_sequence'
         assert doc2.sequences[0].encoding == 'http://www.chem.qmul.ac.uk/iubmb/misc/naseq.html'
         assert doc2.sequences[0].elements == 'tttacagctagctcagtcctaggtattatgctagc'
+
+    def test_3to2_orientation_conversion(self):
+        """Test ability to convert orientation from SBOL3to SBOL2"""
+        # Get the SBOL3 test document
+        tmp_sub = copy_to_tmp(package=['iGEM_SBOL2_imports.nt'])
+        doc3 = sbol3.Document()
+        doc3.read(os.path.join(tmp_sub, 'iGEM_SBOL2_imports.nt'))
+
+        # Convert to SBOL2 and check contents
+        doc2 = convert3to2(doc3)
         # ids of location block containing orientation before conversion
         location_ids_sbol3 = []
-        def change_if_location(o):
+        def append_locationid_with_orientation(o):
             if isinstance(o, sbol3.Location):
                 if hasattr(o, 'orientation') and o.orientation != None:
                     location_ids_sbol3.append(o.identity)
-        doc3.traverse(change_if_location)
+        doc3.traverse(append_locationid_with_orientation)
         # ids of location block containing orientation after conversion
         location_ids_sbol2 = []
         for c in doc2.componentDefinitions:
             for sa in c.sequenceAnnotations:
                 for loc in sa.locations:
-                    if hasattr(loc, 'orientaiton') and loc.orientation != None:
+                    if hasattr(loc, 'orientation') and loc.orientation != None:
                         location_ids_sbol2.append(loc.identity)
                         assert loc.orientation != 'http://sbols.org/v3#inline'
+        assert len(location_ids_sbol2) == 12
         assert collections.Counter(location_ids_sbol2) == collections.Counter(location_ids_sbol3)
-
 
     def test_genbank_conversion(self):
         """Test ability to convert from SBOL3 to GenBank"""


### PR DESCRIPTION
Hi @jakebeal, tried to work on the issue #83,

1. In the function convert3to2 I have removed the part where orientation were mapped again after conversion to SBOL2 document.
2. For the test for validation of orientation I have compaired orientation string to 'http://sbols.org/v3#inline' and if it  matches to the string test fails since it must not be present in an SBOL2 document.

