### PR TITLE
add test for design_file_type with GenBank extension and full path support

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -36,6 +36,7 @@ class TestHelpers(unittest.TestCase):
         assert design_file_type('something.xlsx') == None
         assert design_file_type('something.xml') == 'SBOL2'
         assert design_file_type('something.nt') == 'SBOL3'
+        assert design_file_type('full path/full/path/something.genbank') == 'GenBank'
         assert strip_filetype_suffix('http://foo/bar/baz.gb') == 'http://foo/bar/baz'
         assert strip_filetype_suffix('http://foo/bar/baz.qux') == 'http://foo/bar/baz.qux'
 


### PR DESCRIPTION
I noticed that GenBank extension support is not being tested, and also the full path support is not tested. So I added 1 test to cover both. 