### PR TITLE
Add fiilter by roles functionality

### DIFF
--- a/sbol_utilities/component.py
+++ b/sbol_utilities/component.py
@@ -36,6 +36,21 @@ def contained_components(roots: Union[sbol3.TopLevel, Iterable[sbol3.TopLevel]])
     return {c for c in explored if isinstance(c, sbol3.Component)}
 
 
+def filter_by_roles(doc: sbol3.Document, required_role: str) -> List[sbol3.Identified]:
+    """Search the entire provided document, and return components which have specified role as one of its roles.
+
+    :param doc: sbol3 document to search in
+    :param required_role: the role which must be present in components
+    :return: list of matched components
+    """
+    # callable to be provided as an arg to find_all() of Document class
+    def has_role(obj: sbol3.Identified) -> bool:
+        return isinstance(obj, sbol3.Component) and required_role in obj.roles
+
+    # search through all Identified objects
+    return doc.find_all(has_role)
+
+
 def ensure_singleton_feature(system: sbol3.Component, target: Union[sbol3.Feature, sbol3.Component]):
     """Return a feature associated with the target, i.e., the target itself if a feature, or a SubComponent.
     If the target is not already in the system, add it.

--- a/test/test_component.py
+++ b/test/test_component.py
@@ -7,7 +7,7 @@ import sbol3
 import tyto
 
 from sbol_utilities.component import contained_components, contains, add_feature, add_interaction, constitutive, \
-    regulate, order, in_role, all_in_role, ensure_singleton_feature
+    regulate, order, in_role, all_in_role, ensure_singleton_feature, filter_by_roles
 from sbol_utilities.component import dna_component_with_sequence, rna_component_with_sequence, \
     protein_component_with_sequence, media, functional_component, promoter, rbs, cds, terminator, \
     protein_stability_element, gene, operator, engineered_region, mrna, transcription_factor, \
@@ -16,6 +16,21 @@ from sbol_utilities.sbol_diff import doc_diff
 
 
 class TestComponent(unittest.TestCase):
+
+    def test_filter_by_roles(self):
+        """Test the filter by roles utility"""
+        doc = sbol3.Document()
+        sbol3.set_namespace('http://sbolstandard.org/testfiles')
+        # create and add 3 components, with 2 having common role of dna
+        comp_1 = sbol3.Component('component_1', sbol3.SBO_DNA, roles=[tyto.SBO.deoxyribonucleic_acid])
+        comp_2 = sbol3.Component('component_2', sbol3.SBO_DNA, roles=[tyto.SO.engineered_region])
+        comp_3 = sbol3.Component('component_3', sbol3.SBO_DNA, roles=[tyto.SO.engineered_region, tyto.SBO.deoxyribonucleic_acid])
+        doc.add(comp_1)
+        doc.add(comp_2)
+        doc.add(comp_3)
+        # only comp_1 and comp_3 must be returned by the function
+        matched = filter_by_roles(doc, tyto.SBO.deoxyribonucleic_acid)
+        assert(comp_1 in matched and comp_3 in matched and len(matched) == 2)
 
     def test_system_building(self):
         doc = sbol3.Document()


### PR DESCRIPTION
This adds the ability to filter a document's components by roles, as discussed in [this issue](https://github.com/SynBioDex/pySBOL3/issues/204).
Also added a test for the same.