### PR TITLE
Filter top level objects by any criteria

### DIFF
--- a/sbol_utilities/component.py
+++ b/sbol_utilities/component.py
@@ -56,7 +56,8 @@ def is_dna_part(obj: sbol3.Component) -> bool:
         return any(tyto.SO.get_term_by_uri(role) for role in component.roles)
 
     # check all conditions
-    return check_roles(obj) and has_dna_type(obj) and len(obj.sequences) == 1
+    return isinstance(obj, sbol3.Component) and check_roles(obj) \
+        and has_dna_type(obj) and len(obj.sequences) == 1
 
 
 def ensure_singleton_feature(system: sbol3.Component, target: Union[sbol3.Feature, sbol3.Component]):

--- a/sbol_utilities/helper_functions.py
+++ b/sbol_utilities/helper_functions.py
@@ -1,6 +1,6 @@
 import logging
 import itertools
-from typing import Iterable, Union, Optional
+from typing import Iterable, Union, Optional, Callable, List
 
 import sbol3
 from sbol3.refobj_property import ReferencedURI
@@ -78,6 +78,18 @@ def toplevel_named(doc: sbol3.Document, name: str) -> Optional[sbol3.Identified]
         return found[0]
     else:
         raise ValueError(f'Name is not unique: {name}')
+
+
+def filter_top_level(doc: sbol3.Document, filter: Callable[[sbol3.TopLevel], bool]) -> Iterable[sbol3.TopLevel]:
+    """Filters and returns iterable of TopLevel Objects in a document,
+    which match a criteria set by a callable argument.
+
+    :param doc: SBOL Document to search
+    :param filter: Callable acting as filter on List of TopLevel objects
+    :return: TopLevel iterator satisfying given filter
+    """
+    result: List[sbol3.TopLevel] = [obj for obj in doc.objects if filter(obj)]
+    return iter(result)
 
 
 def strip_sbol2_version(identity: str) -> str:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+from sbol_utilities import component
 
 from sbol_utilities.helper_functions import *
 
@@ -26,6 +28,21 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(design_file_type('full path/full/path/something.genbank'), 'GenBank')
         self.assertEqual(strip_filetype_suffix('http://foo/bar/baz.gb'), 'http://foo/bar/baz')
         self.assertEqual(strip_filetype_suffix('http://foo/bar/baz.qux'), 'http://foo/bar/baz.qux')
+
+    def test_filtering_top_level_objects(self):
+        """Check filtering Top Level Objects by a condition"""
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        sbol3.set_namespace('http://sbolstandard.org/testfiles')
+        # we consider simple_library document for the test
+        simple_library = os.path.join(test_dir, 'test_files', 'simple_library.nt')
+        doc = sbol3.Document()
+        doc.read(simple_library)
+
+        # we check for the no of dna parts in doc
+        self.assertEqual(len(doc.objects), 68, f'Expected 34 TopLevel Objects, found {len(doc.objects)}')
+        itr = filter_top_level(doc, component.is_dna_part)
+        total_filtered = sum(1 for _ in itr)
+        self.assertEqual(total_filtered, 24, f'Expected 24 Objects to satisfy filter, found {total_filtered}')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi @jakebeal , as a follow-up to #108 , I have tried #71.
It returns an iterable of top-level objects, and the test uses the newly added check in #108 on the `simple_library.nt` test file.