### PR TITLE
Add build_reference_cache to accelerate lookup

### DIFF
--- a/sbol_utilities/helper_functions.py
+++ b/sbol_utilities/helper_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 import logging
 import itertools
-from typing import Iterable, Union, Optional, Callable, List
+from typing import Iterable, Union, Optional, Callable
 
 import sbol3
 from sbol3.refobj_property import ReferencedURI
@@ -46,8 +46,9 @@ def build_reference_cache(doc: sbol3.Document) -> dict[str, sbol3.Identified]:
     :returns: a cache of identities
     """
     cache = {}
-    def cache_identity(object: sbol3.Identified):
-        cache[object.identity] = object
+
+    def cache_identity(obj: sbol3.Identified):
+        cache[obj.identity] = obj
     doc.traverse(cache_identity)
     return cache
 
@@ -56,14 +57,19 @@ def find_child(ref: ReferencedURI, cache: Optional[dict[str, sbol3.Identified]] 
     """Look up a child object; if it is not found, raise an exception
 
     :param ref: reference to look up
+    :param cache: optional cache of identities to speed lookup
     :returns: object pointed to by reference
     :raises ChildNotFound: if object cannot be retrieved
     """
     try:
         return cache[str(ref)]
     except KeyError:
+        # KeyError means the item was not found in the cache. Ignore
+        # the error and fall through to a lookup below.
         pass
     except TypeError:
+        # TypeError probably means the cache object is not subscriptable.
+        # Ignore the error and fall through to a lookup below.
         pass
     child = ref.lookup()
     if not child:
@@ -75,14 +81,19 @@ def find_top_level(ref: ReferencedURI, cache: Optional[dict[str, sbol3.Identifie
     """Look up a top-level object; if it is not found, raise an exception
 
     :param ref: reference to look up
+    :param cache: optional cache of identities to speed lookup
     :returns: object pointed to by reference
     :raises TopLevelNotFound: if object cannot be retrieved
     """
     try:
         return cache[str(ref)]
     except KeyError:
+        # KeyError means the item was not found in the cache. Ignore
+        # the error and fall through to a lookup below.
         pass
     except TypeError:
+        # TypeError probably means the cache object is not subscriptable.
+        # Ignore the error and fall through to a lookup below.
         pass
     top_level = ref.lookup()
     if not top_level:

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -44,5 +44,37 @@ class TestHelpers(unittest.TestCase):
         total_filtered = sum(1 for _ in itr)
         self.assertEqual(total_filtered, 24, f'Expected 24 Objects to satisfy filter, found {total_filtered}')
 
+    def test_build_reference_cache(self):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        test_file = os.path.join(test_dir, 'test_files', 'expanded_with_sequences.nt')
+        doc = sbol3.Document()
+        doc.read(test_file)
+        cache = build_reference_cache(doc)
+        # There are 529 occurrences of '22-rdf-syntax-ns#type' in expanded_with_sequences.nt,
+        # which in this particular case means there are 529 separate sbol objects. That's not
+        # always the case, but is the case here.
+        self.assertEqual(529, len(cache))
+        # plant a fake item in the cache and make sure the relevant functions
+        # find it. This tests that they are actually using the cache.
+        sbol3.set_namespace('https://github.com/synbiodex/sbol-utilities')
+        sequence = sbol3.Sequence('seq1')
+        c1 = sbol3.Component('c1', types=[sbol3.SBO_DNA], sequences=[sequence])
+        doc.add(c1)
+        cache[sequence.identity] = sequence
+        # The sequence is not found without the cache because it is not in the document
+        with self.assertRaises(ChildNotFound):
+            found_object = find_child(c1.sequences[0])
+        with self.assertRaises(TopLevelNotFound):
+            found_object = find_top_level(c1.sequences[0])
+        # Using the cache finds the sequence because we manually added
+        # the sequence to the cache to test that the functions are
+        # actually using the cache. This is not the expected usage
+        # pattern, this is only for unit testing.
+        found_object = find_child(c1.sequences[0], cache)
+        self.assertEqual(sequence, found_object)
+        found_object = find_top_level(c1.sequences[0], cache)
+        self.assertEqual(sequence, found_object)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Look up of referenced objects is slow in large documents. Accelerate the lookup through the use of a cache. Add `build_reference_cache` to build the cache, and accept the cache as an optional argument to `find_child` and `find_top_level`.

Use the cache in `compute_sequence` and `calculate_sequences`.