### PR TITLE
Add a reference cache context manager

### DIFF
--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -75,6 +75,47 @@ class TestHelpers(unittest.TestCase):
         found_object = find_top_level(c1.sequences[0], cache)
         self.assertEqual(sequence, found_object)
 
+    def test_with_cached_references(self):
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        test_file = os.path.join(test_dir, 'test_files', 'expanded_with_sequences.nt')
+        doc = sbol3.Document()
+        doc.read(test_file)
+        target_uri = 'http://sbolstandard.org/testfiles/mmilCFP'
+        # The document should not have the secret reference cache attribute
+        self.assertFalse(hasattr(doc, '_sbol_utilities_reference_cache'))
+        with cached_references(doc):
+            # Now the document should have the secret reference cache attribute
+            self.assertTrue(hasattr(doc, '_sbol_utilities_reference_cache'))
+            # We know there are 529 objects in the document. Use that to verify the cache length.
+            self.assertEqual(529, len(doc._sbol_utilities_reference_cache))
+            # The target uri should be in the cache
+            self.assertIn(target_uri, doc._sbol_utilities_reference_cache)
+            obj = doc.find(target_uri)
+            self.assertEqual(target_uri, obj.identity)
+        # Make sure find_child and find_top_level are using the hidden cache
+        with cached_references(doc) as reference_cache:
+            # plant a fake item in the cache and make sure the relevant functions
+            # find it. This tests that they are actually using the cache.
+            sbol3.set_namespace('https://github.com/synbiodex/sbol-utilities')
+            sequence = sbol3.Sequence('seq1')
+            c1 = sbol3.Component('c1', types=[sbol3.SBO_DNA], sequences=[sequence])
+            doc.add(c1)
+            with self.assertRaises(ChildNotFound):
+                find_child(c1.sequences[0])
+            with self.assertRaises(TopLevelNotFound):
+                find_top_level(c1.sequences[0])
+            reference_cache[sequence.identity] = sequence
+            # Pass the cache explicitly to find the objects
+            found_object = find_child(c1.sequences[0], reference_cache)
+            self.assertEqual(sequence, found_object)
+            found_object = find_top_level(c1.sequences[0], reference_cache)
+            self.assertEqual(sequence, found_object)
+            # Use the implicit/hidden/secret cache to find objects
+            found_object = find_child(c1.sequences[0])
+            self.assertEqual(sequence, found_object)
+            found_object = find_top_level(c1.sequences[0])
+            self.assertEqual(sequence, found_object)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add a context manager for a reference cache so that it can be used in a `with` statement. The resulting cache can be passed explicitly to find_child or find_top_level, or it can be passed implicitly because the cache is stored on a hidden attribute on the document.

Sample usage, passing the cache explicitly:
```python
with cached_references(doc) as cache:
        find_top_level(component1.sequences[0], cache)
```

Sample usage, passing the cache implicitly:
```python
with cached_references(doc):
        find_top_level(component1.sequences[0])
```
