### PR TITLE
add: initial simple conversion gb/sbol3 with sample files

### DIFF
--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -1,37 +1,42 @@
 import os
 import sbol3
-sbol3.set_namespace("https://testing.sbol3.genbank/")
 from Bio import GenBank
 GENBANK_PARSER = GenBank.RecordParser()
 
 # Conversion Constants (NOTE: most are placeholding and temporary for now)
-SAMPLE_GB_FILE_1 = "BBa_J23101.gb"          # Simplest file in genbank consisting only of a singular sequence
+SAMPLE_GB_FILE_1 = "BBa_J23101.gb"          
+# Simplest file in genbank consisting only of a singular sequence
 SAMPLE_SBOL3_FILE_1 = "BBa_J23101_from_genbank_to_sbol3_direct.nt"
-COMP_TYPES = [sbol3.SBO_DNA]                # Temporarily assuming only dna components to be dealt with in genbank files
-COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   # Temporarilty assuming components to only have the engineered_region role
-GENBANK_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
+# Temporarily assuming only dna components to be dealt with in genbank files
+COMP_TYPES = [sbol3.SBO_DNA]                
+# Temporarilty assuming components to only have the engineered_region role
+COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   
+GENBANK_FILE_1 = os.path.join(os.path.abspath(os.path.curdir),
                     "test/test_files", SAMPLE_GB_FILE_1)
-SBOL3_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
+SBOL3_FILE_1 = os.path.join(os.path.abspath(os.path.curdir),
                     "test/test_files", SAMPLE_SBOL3_FILE_1)
 
-def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str, write: bool = False):
+def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str, 
+                    namespace: str = "https://testing.sbol3.genbank/", write: bool = False):
     # create sbol3 document, and record parser handler for gb file
+    sbol3.set_namespace(namespace)
     doc = sbol3.Document()
     record = GENBANK_PARSER.parse(open(gb_file))
     # NOTE: Currently we assume only linear or circular topology is possible
     COMP_TYPES.append(sbol3.SO_LINEAR if record.topology == "linear" else sbol3.SO_CIRCULAR)
-    comp = sbol3.Component(identity=record.accession[0], \
-                    types=COMP_TYPES, \
-                    roles=COMP_ROLES, \
+    comp = sbol3.Component(identity=record.accession[0],
+                    types=COMP_TYPES,
+                    roles=COMP_ROLES,
                     description=record.definition)
     doc.add(comp)
     # NOTE: Currently we use a single method of encoding (IUPAC)
-    seq = sbol3.Sequence(identity=record.accession[0] + "_sequence", \
-                    elements=record.sequence.lower(), \
+    seq = sbol3.Sequence(identity=record.accession[0] + "_sequence",
+                    elements=record.sequence.lower(),
                     encoding=sbol3.IUPAC_DNA_ENCODING)
     doc.add(seq)
     comp.sequences = [seq]
-    if write: doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
+    if write: 
+        doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
     return doc
 
 

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -30,7 +30,7 @@ def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str, write: bool = False)
                     elements=record.sequence.lower(), \
                     encoding=sbol3.IUPAC_DNA_ENCODING)
     doc.add(seq)
-    comp.sequences = [ seq ]
+    comp.sequences = [seq]
     if write: doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
     return doc
 

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -14,7 +14,7 @@ SBOL3_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
 COMP_TYPES = [sbol3.SBO_DNA]                # Temporarily assuming only dna components to be dealt with in genbank files
 COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   # Temporarilty assuming components to only have the engineered_region role
 
-def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str):
+def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str, write: bool = False):
     # create sbol3 document, and record parser handler for gb file
     doc = sbol3.Document()
     record = GENBANK_PARSER.parse(open(gb_file))
@@ -31,12 +31,13 @@ def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str):
                     encoding=sbol3.IUPAC_DNA_ENCODING)
     doc.add(seq)
     comp.sequences = [ seq ]
-    doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
+    if write: doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
+    return doc
 
 
 # Currently we don't parse input for gb and sbol3 files (hardcoded)
 def main():
-    convert_genbank_to_sbol3(gb_file=GENBANK_FILE_1, sbol3_file=SBOL3_FILE_1)
+    convert_genbank_to_sbol3(gb_file=GENBANK_FILE_1, sbol3_file=SBOL3_FILE_1, write=True)
 
 if __name__ == '__main__':
     main()

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -7,12 +7,12 @@ GENBANK_PARSER = GenBank.RecordParser()
 # Conversion Constants (NOTE: most are placeholding and temporary for now)
 SAMPLE_GB_FILE_1 = "BBa_J23101.gb"          # Simplest file in genbank consisting only of a singular sequence
 SAMPLE_SBOL3_FILE_1 = "BBa_J23101_from_genbank_to_sbol3_direct.nt"
+COMP_TYPES = [sbol3.SBO_DNA]                # Temporarily assuming only dna components to be dealt with in genbank files
+COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   # Temporarilty assuming components to only have the engineered_region role
 GENBANK_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
                     "test/test_files", SAMPLE_GB_FILE_1)
 SBOL3_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
                     "test/test_files", SAMPLE_SBOL3_FILE_1)
-COMP_TYPES = [sbol3.SBO_DNA]                # Temporarily assuming only dna components to be dealt with in genbank files
-COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   # Temporarilty assuming components to only have the engineered_region role
 
 def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str, write: bool = False):
     # create sbol3 document, and record parser handler for gb file

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -1,0 +1,42 @@
+import os
+import sbol3
+sbol3.set_namespace("https://testing.sbol3.genbank/")
+from Bio import GenBank
+GENBANK_PARSER = GenBank.RecordParser()
+
+# Conversion Constants (NOTE: most are placeholding and temporary for now)
+SAMPLE_GB_FILE_1 = "BBa_J23101.gb"          # Simplest file in genbank consisting only of a singular sequence
+SAMPLE_SBOL3_FILE_1 = "BBa_J23101_from_genbank_to_sbol3_direct.nt"
+GENBANK_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
+                    "test/test_files", SAMPLE_GB_FILE_1)
+SBOL3_FILE_1 = os.path.join(os.path.abspath(os.path.curdir), \
+                    "test/test_files", SAMPLE_SBOL3_FILE_1)
+COMP_TYPES = [sbol3.SBO_DNA]                # Temporarily assuming only dna components to be dealt with in genbank files
+COMP_ROLES = [sbol3.SO_ENGINEERED_REGION]   # Temporarilty assuming components to only have the engineered_region role
+
+def convert_genbank_to_sbol3(gb_file: str, sbol3_file: str):
+    # create sbol3 document, and record parser handler for gb file
+    doc = sbol3.Document()
+    record = GENBANK_PARSER.parse(open(gb_file))
+    # NOTE: Currently we assume only linear or circular topology is possible
+    COMP_TYPES.append(sbol3.SO_LINEAR if record.topology == "linear" else sbol3.SO_CIRCULAR)
+    comp = sbol3.Component(identity=record.accession[0], \
+                    types=COMP_TYPES, \
+                    roles=COMP_ROLES, \
+                    description=record.definition)
+    doc.add(comp)
+    # NOTE: Currently we use a single method of encoding (IUPAC)
+    seq = sbol3.Sequence(identity=record.accession[0] + "_sequence", \
+                    elements=record.sequence.lower(), \
+                    encoding=sbol3.IUPAC_DNA_ENCODING)
+    doc.add(seq)
+    comp.sequences = [ seq ]
+    doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
+
+
+# Currently we don't parse input for gb and sbol3 files (hardcoded)
+def main():
+    convert_genbank_to_sbol3(gb_file=GENBANK_FILE_1, sbol3_file=SBOL3_FILE_1)
+
+if __name__ == '__main__':
+    main()

--- a/test/test_files/BBa_J23101_from_genbank_to_sbol3_direct.nt
+++ b/test/test_files/BBa_J23101_from_genbank_to_sbol3_direct.nt
@@ -1,0 +1,14 @@
+
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#description> "constitutive promoter family member" .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#displayId> "BBa_J23101" .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#hasNamespace> <https://testing.sbol3.genbank/> .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#hasSequence> <https://testing.sbol3.genbank/BBa_J23101_sequence> .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#role> <https://identifiers.org/SO:0000804> .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
+<https://testing.sbol3.genbank/BBa_J23101> <http://sbols.org/v3#type> <https://identifiers.org/SO:0000987> .
+<https://testing.sbol3.genbank/BBa_J23101> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<https://testing.sbol3.genbank/BBa_J23101_sequence> <http://sbols.org/v3#displayId> "BBa_J23101_sequence" .
+<https://testing.sbol3.genbank/BBa_J23101_sequence> <http://sbols.org/v3#elements> "tttacagctagctcagtcctaggtattatgctagc" .
+<https://testing.sbol3.genbank/BBa_J23101_sequence> <http://sbols.org/v3#encoding> <https://identifiers.org/edam:format_1207> .
+<https://testing.sbol3.genbank/BBa_J23101_sequence> <http://sbols.org/v3#hasNamespace> <https://testing.sbol3.genbank/> .
+<https://testing.sbol3.genbank/BBa_J23101_sequence> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Sequence> .

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -10,7 +10,8 @@ class TestGenBank2SBOL3(unittest.TestCase):
         sbol3.set_namespace("https://testing.sbol3.genbank/")
         TEST_OUTPUT_SBOL3 = SBOL3_FILE_1 + ".test" 
         # Don't write to file for testing, we directly compare sbol documents
-        test_output_sbol3 = convert_genbank_to_sbol3(GENBANK_FILE_1, TEST_OUTPUT_SBOL3, write=False)
+        test_output_sbol3 = convert_genbank_to_sbol3(GENBANK_FILE_1, TEST_OUTPUT_SBOL3, 
+                            namespace="https://testing.sbol3.genbank/", write=False)
         sbol3_file_1 = sbol3.Document()
         sbol3_file_1.read(location=SBOL3_FILE_1, file_format=sbol3.SORTED_NTRIPLES)
         assert not doc_diff(test_output_sbol3, sbol3_file_1), \

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -1,0 +1,20 @@
+import unittest
+import sbol3
+sbol3.set_namespace("https://testing.sbol3.genbank/")
+from sbol_utilities.sbol_diff import doc_diff
+from sbol_utilities.sbol3_genbank_conversion import convert_genbank_to_sbol3, \
+    GENBANK_FILE_1, SBOL3_FILE_1
+
+class TestGenBank2SBOL3(unittest.TestCase):
+    def test_simple_file_1(self):
+        """Test conversion of a simple genbank file with a single sequence"""
+        TEST_OUTPUT_SBOL3 = SBOL3_FILE_1 + ".test" 
+        # Don't write to file for testing, we directly compare sbol documents
+        test_output_sbol3 = convert_genbank_to_sbol3(GENBANK_FILE_1, TEST_OUTPUT_SBOL3, write=False)
+        sbol3_file_1 = sbol3.Document()
+        sbol3_file_1.read(location=SBOL3_FILE_1, file_format=sbol3.SORTED_NTRIPLES)
+        assert not doc_diff(test_output_sbol3, sbol3_file_1), \
+            f'Converted SBOL3 file: {TEST_OUTPUT_SBOL3} not identical to expected file: {SBOL3_FILE_1}'
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -1,6 +1,5 @@
 import unittest
 import sbol3
-sbol3.set_namespace("https://testing.sbol3.genbank/")
 from sbol_utilities.sbol_diff import doc_diff
 from sbol_utilities.sbol3_genbank_conversion import convert_genbank_to_sbol3, \
     GENBANK_FILE_1, SBOL3_FILE_1
@@ -8,6 +7,7 @@ from sbol_utilities.sbol3_genbank_conversion import convert_genbank_to_sbol3, \
 class TestGenBank2SBOL3(unittest.TestCase):
     def test_simple_file_1(self):
         """Test conversion of a simple genbank file with a single sequence"""
+        sbol3.set_namespace("https://testing.sbol3.genbank/")
         TEST_OUTPUT_SBOL3 = SBOL3_FILE_1 + ".test" 
         # Don't write to file for testing, we directly compare sbol documents
         test_output_sbol3 = convert_genbank_to_sbol3(GENBANK_FILE_1, TEST_OUTPUT_SBOL3, write=False)


### PR DESCRIPTION
### Changes:
* The conversion function takes in the GenBank input file and sbol3 file to write to, though not from the main function directly, it is hardcoded for now as we have it working only for a simple conversion having only 1 sequence in the GenBank file.
* I have included a separate file for unit tests pertaining to this direct conversion. Note that the conversion utility itself is also in a separate file at the moment in order to:
    - Not disturb the existing online conversion.
    - Better handle all test cases as we will probably make many helper functions, and they, along with the conversion function can be merged at the end into the `sbol_utilities.conversion.py` file.
### TODO:
* Make the conversion function available as a console script for the package - may be in a separate issue?