### PR TITLE
add: new converter to existing console script with fallback option to legacy converter

### DIFF
--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -305,8 +305,7 @@ def convert_from_genbank(path: str, namespace: str, allow_genbank_online: bool =
     """
     if force_new_converter:
         converter = GenBank_SBOL3_Converter()
-        doc = converter.convert_genbank_to_sbol3(gb_file=path, namespace=namespace, write=False)
-        return doc
+        return converter.convert_genbank_to_sbol3(gb_file=path, namespace=namespace, write=False)
     doc2 = sbol2.Document()
     sbol2.setHomespace(namespace)
     # Convert document offline

--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -307,14 +307,6 @@ def convert_from_genbank(path: str, namespace: str, allow_genbank_online: bool =
         converter = GenBank_SBOL3_Converter()
         doc = converter.convert_genbank_to_sbol3(gb_file=path, namespace=namespace, write=False)
         return doc
-        # if not doc3:
-        #     logging.error(f"No SBOL3 output document was produced by new converter;\n \
-        #                   Please make sure you have the latest pip package installed.")
-        #     if allow_legacy_converter:
-        #         logging.info(f"Error encountered with conversion using new offline converter, reverting to legacy online converter.")
-        #         doc3 = convert_from_genbank(input_file, namespace, args_dict['allow_genbank_online'])
-        #     else:
-        #         return
     doc2 = sbol2.Document()
     sbol2.setHomespace(namespace)
     # Convert document offline
@@ -423,7 +415,7 @@ def command_line_converter(args_dict: Dict[str, Any]):
         raise ValueError(f'Unknown file type {input_file_type}; should have been caught earlier')
 
     # Convert output from SBOL3
-    if doc3: logging.info('Writing output file '+output_file)
+    logging.info('Writing output file '+output_file)
     if output_file_type == 'FASTA':
         convert_to_fasta(doc3, output_file)
     elif output_file_type == 'GenBank':
@@ -437,7 +429,7 @@ def command_line_converter(args_dict: Dict[str, Any]):
         finally:
             sbol2.Config.setOption(sbol2.ConfigOptions.VALIDATE_ONLINE, validate_online)
     elif output_file_type == 'SBOL3':
-        if doc3: doc3.write(output_file, sbol3.SORTED_NTRIPLES)
+        doc3.write(output_file, sbol3.SORTED_NTRIPLES)
     else:
         raise ValueError(f'Unknown file type {output_file_type}; should have been caught earlier')
 
@@ -456,6 +448,8 @@ def main():
                         help="Print running explanation of conversion process")
     parser.add_argument('--allow-genbank-online', dest='allow_genbank_online', action='store_true', default=False,
                         help='Perform GenBank conversion using online converter')
+    parser.add_argument('--force-new-converter', dest='force_new_converter', action='store_true', default=False,
+                        help='Force the usage of new (offline) converter instead of legacy (online) converter.')
     args_dict = vars(parser.parse_args())
     # Call the shared command-line conversion routine
     command_line_converter(args_dict)
@@ -542,6 +536,8 @@ def sbol2genbank():
                         help="Print running explanation of conversion process")
     parser.add_argument('--allow-genbank-online', dest='allow_genbank_online', action='store_true', default=False,
                         help='Perform GenBank conversion using online converter')
+    parser.add_argument('--force-new-converter', dest='force_new_converter', action='store_true', default=False,
+                        help='Force the usage of new (offline) converter instead of legacy (online) converter.')
     args_dict = vars(parser.parse_args())
     args_dict['input_file_type'] = 'SBOL3'
     args_dict['output_file_type'] = 'GenBank'

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -124,11 +124,11 @@ class GenBank_SBOL3_Converter:
             gb2so_csv=GB2SO_MAPPINGS_CSV, convert_so2gb=False
         )
         if not map_created:
-            logging.critical(
+            # TODO: Need better SBOL3-GenBank specific error classes in future
+            raise ValueError(
                 f"Required CSV data files are not present in your package.\n    Please reinstall the sbol_utilities package.\n \
                 Stopping current conversion process.\n    Reverting to legacy converter if new Conversion process is not forced."
             )
-            return None
         # access records by parsing gb file using SeqIO class
         logging.info(
             f"Parsing Genbank records using SeqIO class.\n    Using GenBank file {gb_file}"

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -135,7 +135,7 @@ class GenBank_SBOL3_Converter:
         )
         for record in list(SeqIO.parse(gb_file, "genbank").records):
             # NOTE: Currently we assume only linear or circular topology is possible
-            logging.info(f"Parsing record - {record.id} in genbank file.")
+            logging.info(f"Parsing record - `{record.id}` in genbank file.")
             if record.annotations["topology"] == "linear":
                 extra_comp_types = [sbol3.SO_LINEAR]
             else:
@@ -164,7 +164,7 @@ class GenBank_SBOL3_Converter:
                 comp.features = []
                 for gb_feat in record.features:
                     logging.info(
-                        f"Parsing feature {gb_feat.qualifiers['label'][0]} for record {record.id}"
+                        f"Parsing feature `{gb_feat.qualifiers['label'][0]}` for record `{record.id}`"
                     )
                     # create "Range/Cut" FeatureLocation by parsing genbank record location
                     gb_loc = gb_feat.location

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -12,6 +12,7 @@ import sbol3
 from sbol_utilities.conversion import convert2to3, convert3to2, convert_to_genbank, convert_to_fasta, \
     convert_from_fasta, convert_from_genbank, \
     main, sbol2fasta, sbol2genbank, sbol2to3, sbol3to2, fasta2sbol, genbank2sbol
+from sbol_utilities.sbol3_genbank_conversion import TEST_NAMESPACE
 from helpers import copy_to_tmp
 from sbol_utilities.sbol_diff import doc_diff
 # TODO: Add command-line utilities and test them too
@@ -162,6 +163,23 @@ class Test2To3Conversion(unittest.TestCase):
         # Note: cannot directly round-trip because converter is a) lossy, and b) inserts extra materials
         test_dir = os.path.dirname(os.path.realpath(__file__))
         comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_genbank.nt')
+        comparison_doc = sbol3.Document()
+        comparison_doc.read(comparison_file)
+        assert not doc_diff(doc3, comparison_doc), f'Converted GenBank file not identical to {comparison_file}'
+
+    def test_conversion_from_genbank_new_converter(self):
+        """Test ability to convert from GenBank to SBOL3 using new converter
+        by specifying the `--force-new-converter` flag """
+        # Get the GenBank test document and convert
+        tmp_sub = copy_to_tmp(package=['BBa_J23101.gb'])
+        doc3 = convert_from_genbank(path=os.path.join(tmp_sub, 'BBa_J23101.gb'),
+                                    namespace=TEST_NAMESPACE,
+                                    allow_genbank_online=False,
+                                    force_new_converter=True)
+
+        # Note: cannot directly round-trip because converter is a) lossy, and b) inserts extra materials
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_genbank_to_sbol3_direct.nt')
         comparison_doc = sbol3.Document()
         comparison_doc.read(comparison_file)
         assert not doc_diff(doc3, comparison_doc), f'Converted GenBank file not identical to {comparison_file}'


### PR DESCRIPTION
## Changes:
* Existing executable commands `sbol2genbank`, `genbank2sbol`, `sbol-converter` now have an added flag `--force-new-converter`, which upon invoking would carry out the given conversion process using the new offline converter.
* This conversion would throw Errors in case of not being able to carry out certain parts of the conversion process.
* A new unit test, `test_genbank_conversion_new_converter`, has been added, which will test the converted output using the new force flag.
* This test uses the previously added test file: `BBa_J23101_from_genbank_to_sbol3_direct.nt` to convert the sbol3 document to genbank which is compared against the test file: `BBa_J23101_from_sbol3_direct.gb`.

## TODO:
* Add an option to revert to the legacy converter in case of any errors while using the new converter. (Long Term Issue)