### PR TITLE
add: new support for SBOL3 to GenBank conversion

### DIFF
--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -402,10 +402,7 @@ def command_line_converter(args_dict: Dict[str, Any]):
     if input_file_type == 'FASTA':
         doc3 = convert_from_fasta(input_file, namespace)
     elif input_file_type == 'GenBank':
-        doc3 = convert_from_genbank(path=input_file,
-                                    namespace=namespace,
-                                    allow_genbank_online=args_dict['allow_genbank_online'],
-                                    force_new_converter=args_dict['force_new_converter'])
+        doc3 = convert_from_genbank(input_file, namespace, args_dict['allow_genbank_online'], args_dict['force_new_converter'])
     elif input_file_type == 'SBOL2':
         doc2 = sbol2.Document()
         doc2.read(input_file)
@@ -421,7 +418,7 @@ def command_line_converter(args_dict: Dict[str, Any]):
     if output_file_type == 'FASTA':
         convert_to_fasta(doc3, output_file)
     elif output_file_type == 'GenBank':
-        convert_to_genbank(doc3=doc3, path=output_file, allow_genbank_online=args_dict['allow_genbank_online'], force_new_converter=args_dict['force_new_converter'])
+        convert_to_genbank(doc3, output_file, args_dict['allow_genbank_online'], args_dict['force_new_converter'])
     elif output_file_type == 'SBOL2':
         doc2 = convert3to2(doc3)
         validate_online = sbol2.Config.getOption(sbol2.ConfigOptions.VALIDATE_ONLINE)

--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -320,7 +320,7 @@ def convert_from_genbank(path: str, namespace: str, allow_genbank_online: bool =
     return doc
 
 
-def convert_to_genbank(doc3: sbol3.Document, path: str, allow_genbank_online: bool = False) \
+def convert_to_genbank(doc3: sbol3.Document, path: str, allow_genbank_online: bool = False, force_new_converter: bool = False) \
         -> List[SeqRecord.SeqRecord]:
     """Convert an SBOL3 document to a GenBank file, which is written to disk
     Note that for compatibility with version control software, if no prov:modified term is available on each Component,
@@ -331,6 +331,9 @@ def convert_to_genbank(doc3: sbol3.Document, path: str, allow_genbank_online: bo
     :param allow_genbank_online: use the online converter rather than the local converter
     :return: BioPython SeqRecord of the GenBank that was written
     """
+    if force_new_converter:
+        converter = GenBank_SBOL3_Converter()
+        return converter.convert_sbol3_to_genbank(sbol3_file=None, doc=doc3, gb_file=path, write=True)
     # first convert to SBOL2, then export to a temp GenBank file
     doc2 = convert3to2(doc3)
 
@@ -418,7 +421,7 @@ def command_line_converter(args_dict: Dict[str, Any]):
     if output_file_type == 'FASTA':
         convert_to_fasta(doc3, output_file)
     elif output_file_type == 'GenBank':
-        convert_to_genbank(doc3, output_file, args_dict['allow_genbank_online'])
+        convert_to_genbank(doc3=doc3, path=output_file, allow_genbank_online=args_dict['allow_genbank_online'], force_new_converter=args_dict['force_new_converter'])
     elif output_file_type == 'SBOL2':
         doc2 = convert3to2(doc3)
         validate_online = sbol2.Config.getOption(sbol2.ConfigOptions.VALIDATE_ONLINE)

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -61,16 +61,12 @@ SO2GB_MAPPINGS_CSV = os.path.join(
 class GenBank_SBOL3_Converter:
     gb2so_map = {}
     so2gb_map = {}
-    default_SO_ontology = "SO:0000110"
-    default_GB_ontology = "todo"  # TODO: Whats the default here?
+    DEFAULT_GB_REC_VERSION = 1
+    DEFAULT_SO_TERM = "SO:0000110"
+    DEFAULT_GB_TERM = "todo"  # TODO: Whats the default here?
 
-    def create_GB_SO_role_mappings(
-        self,
-        gb2so_csv: str = GB2SO_MAPPINGS_CSV,
-        so2gb_csv: str = SO2GB_MAPPINGS_CSV,
-        convert_gb2so: bool = True,
-        convert_so2gb: bool = True,
-    ):
+    def create_GB_SO_role_mappings(self, gb2so_csv: str = GB2SO_MAPPINGS_CSV, so2gb_csv: str = SO2GB_MAPPINGS_CSV,
+                                   convert_gb2so: bool = True, convert_so2gb: bool = True):
         """Reads 2 CSV Files containing mappings for converting between GenBank and SO ontologies roles
         :param gb2so_csv: path to read genbank to so conversion csv file
         :param so2gb_csv: path to read so to genbank conversion csv file
@@ -99,13 +95,8 @@ class GenBank_SBOL3_Converter:
                 return 0
         return 1
 
-    def convert_genbank_to_sbol3(
-        self,
-        gb_file: str,
-        sbol3_file: str = "sbol3.out",
-        namespace: str = TEST_NAMESPACE,
-        write: bool = False,
-    ) -> sbol3.Document:
+    def convert_genbank_to_sbol3(self, gb_file: str, sbol3_file: str = "sbol3.out", namespace: str = TEST_NAMESPACE,
+                                 write: bool = False) -> sbol3.Document:
         """Convert a GenBank document on disk into an SBOL3 document
         The GenBank document is parsed using BioPython, and corresponding objects of SBOL3 document are created
 
@@ -196,7 +187,7 @@ class GenBank_SBOL3_Converter:
                     if self.gb2so_map.get(gb_feat.type):
                         feat_role += self.gb2so_map[gb_feat.type]
                     else:
-                        feat_role += self.default_SO_ontology
+                        feat_role += self.DEFAULT_SO_TERM
                     feat = sbol3.SequenceFeature(
                         locations=[locs],
                         roles=[feat_role],
@@ -210,13 +201,8 @@ class GenBank_SBOL3_Converter:
             doc.write(fpath=sbol3_file, file_format=sbol3.SORTED_NTRIPLES)
         return doc
 
-    def convert_sbol3_to_genbank(
-        self,
-        sbol3_file: str,
-        doc: sbol3.Document = None,
-        gb_file: str = "genbank.out",
-        write: bool = False,
-    ) -> List[SeqRecord]:
+    def convert_sbol3_to_genbank(self, sbol3_file: str, doc: sbol3.Document = None, gb_file: str = "genbank.out",
+                                 write: bool = False) -> List[SeqRecord]:
         """Convert a SBOL3 document on disk into a GenBank document
         The GenBank document is made using an array of SeqRecords using BioPython, by parsing SBOL3 objects
 
@@ -261,6 +247,9 @@ class GenBank_SBOL3_Converter:
                 seq_rec.annotations["molecule_type"] = "DNA"
                 # TODO: hardcoded topology as linear, derivation?
                 seq_rec.annotations["topology"] = "linear"
+                # TODO: temporalily hardcoding version as "1"
+                # FIXME: Version still not being displayed on record's VERSION
+                seq_rec.annotations["sequence_version"] = self.DEFAULT_GB_REC_VERSION
                 SEQ_REC_FEATURES = []
                 if obj.features:
                     # converting all sequence features
@@ -287,7 +276,7 @@ class GenBank_SBOL3_Converter:
                             obj_feat.roles[0].index(":", 6) - 2 :
                         ]
                         # Obtain sequence feature role from so2gb mappings
-                        feat_role = self.default_GB_ontology
+                        feat_role = self.DEFAULT_GB_TERM
                         if self.so2gb_map.get(obj_feat_role):
                             feat_role = self.so2gb_map[obj_feat_role]
                         # create sequence feature object with label qualifier

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -243,9 +243,7 @@ class GenBank_SBOL3_Converter:
                 Stopping current conversion process.\n    Reverting to legacy converter if new Conversion process is not forced."
             )
         # consider sbol3 objects which are components
-        logging.info(
-            f"Parsing SBOL3 Document components using SBOL3 Document: \n{doc}"
-        )
+        logging.info(f"Parsing SBOL3 Document components using SBOL3 Document: \n{doc}")
         for obj in doc.objects:
             if isinstance(obj, sbol3.Component):
                 SEQ_REC_FEATURES = []
@@ -254,7 +252,12 @@ class GenBank_SBOL3_Converter:
                 obj_seq = doc.find(obj.sequences[0])
                 seq = Seq(obj_seq.elements.upper())
                 # TODO: "Version" annotation information currently not stored when converted genbank to sbol3
-                seq_rec = SeqRecord(seq=seq, id=obj.display_id, description=obj.description, name=obj.display_id)
+                seq_rec = SeqRecord(
+                    seq=seq,
+                    id=obj.display_id,
+                    description=obj.description,
+                    name=obj.display_id,
+                )
                 # TODO: hardcoded molecule_type as DNA, derivation?
                 seq_rec.annotations["molecule_type"] = "DNA"
                 # TODO: hardcoded topology as linear, derivation?
@@ -268,26 +271,37 @@ class GenBank_SBOL3_Converter:
                         obj_feat_loc = obj_feat.locations[0]
                         feat_strand = 1
                         # feature strand value which denotes orientation of the location of the feature
-                        if obj_feat_loc.orientation == sbol3.SO_FORWARD: feat_strand = 1
-                        elif obj_feat_loc.orientation == sbol3.SO_REVERSE: feat_strand = -1
-                        feat_loc = FeatureLocation(start=obj_feat_loc.start - 1, end=obj_feat_loc.end, strand=feat_strand)
-                        # TODO: Raise custom converter class ERROR for `else:` 
+                        if obj_feat_loc.orientation == sbol3.SO_FORWARD:
+                            feat_strand = 1
+                        elif obj_feat_loc.orientation == sbol3.SO_REVERSE:
+                            feat_strand = -1
+                        feat_loc = FeatureLocation(
+                            start=obj_feat_loc.start - 1,
+                            end=obj_feat_loc.end,
+                            strand=feat_strand,
+                        )
+                        # TODO: Raise custom converter class ERROR for `else:`
                         # FIXME: order of features not same as original genbank doc?
                         obj_feat_role = obj_feat.roles[0]
-                        obj_feat_role = obj_feat_role[obj_feat.roles[0].index(":", 5) - 2:]
+                        obj_feat_role = obj_feat_role[
+                            obj_feat.roles[0].index(":", 5) - 2 :
+                        ]
                         # Obtain sequence feature role from so2gb mappings
                         feat_role = self.default_GB_ontology
                         if self.so2gb_map.get(obj_feat_role):
                             feat_role = self.so2gb_map[obj_feat_role]
                         # create sequence feature object with label qualifier
-                        feat = SeqFeature(location=feat_loc, strand=feat_strand, type=feat_role)
-                        if obj_feat.name: feat.qualifiers['label'] = obj_feat.name
+                        feat = SeqFeature(
+                            location=feat_loc, strand=feat_strand, type=feat_role
+                        )
+                        if obj_feat.name:
+                            feat.qualifiers["label"] = obj_feat.name
                         # add feature to list of features
                         SEQ_REC_FEATURES.append(feat)
                         seq_rec.features = SEQ_REC_FEATURES
                 SEQ_RECORDS.append(seq_rec)
         # writing generated genbank document to disk at path provided
-        if write: 
+        if write:
             logging.info(
                 f"Writing created genbank file to disk.\n    With path {gb_file}"
             )

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -62,7 +62,7 @@ class GenBank_SBOL3_Converter:
     gb2so_map = {}
     so2gb_map = {}
     DEFAULT_SO_TERM = "SO:0000110"
-    DEFAULT_GB_TERM = "todo"  # TODO: Whats the default here?
+    DEFAULT_GB_TERM = "misc_feature"
     BIO_STRAND_FORWARD = 1
     BIO_STRAND_REVERSE = -1
     DEFAULT_GB_REC_VERSION = 1

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -167,6 +167,20 @@ class Test2To3Conversion(unittest.TestCase):
         comparison_doc.read(comparison_file)
         assert not doc_diff(doc3, comparison_doc), f'Converted GenBank file not identical to {comparison_file}'
 
+    def test_genbank_conversion_new_converter(self):
+        """Test ability to convert from SBOL3 to GenBank using new converter
+        by specifying the `--force-new-converter` flag """
+        # Get the SBOL3 test document
+        tmp_sub = copy_to_tmp(package=['BBa_J23101_from_genbank_to_sbol3_direct.nt'])
+        doc3 = sbol3.Document()
+        doc3.read(os.path.join(tmp_sub, 'BBa_J23101_from_genbank_to_sbol3_direct.nt'))
+        # Convert to GenBank and check contents
+        outfile = os.path.join(tmp_sub, 'BBa_J23101.gb')
+        convert_to_genbank(doc3=doc3, path=outfile, allow_genbank_online=False, force_new_converter=True)
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_sbol3_direct.gb')
+        assert filecmp.cmp(outfile, comparison_file), f'Converted GenBank file {comparison_file} is not identical'
+
     def test_conversion_from_genbank_new_converter(self):
         """Test ability to convert from GenBank to SBOL3 using new converter
         by specifying the `--force-new-converter` flag """
@@ -182,7 +196,7 @@ class Test2To3Conversion(unittest.TestCase):
         comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_genbank_to_sbol3_direct.nt')
         comparison_doc = sbol3.Document()
         comparison_doc.read(comparison_file)
-        assert not doc_diff(doc3, comparison_doc), f'Converted GenBank file not identical to {comparison_file}'
+        assert not doc_diff(doc3, comparison_doc), f'Converted SBOL3 file not identical to {comparison_file}'
 
     def test_genbank_multi_conversion(self):
         """Test ability to convert from SBOL3 to GenBank"""

--- a/test/test_files/BBa_J23101_from_sbol3_direct.gb
+++ b/test/test_files/BBa_J23101_from_sbol3_direct.gb
@@ -1,0 +1,12 @@
+LOCUS       BBa_J23101                35 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  constitutive promoter family member.
+ACCESSION   BBa_J23101
+VERSION     BBa_J23101
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 tttacagcta gctcagtcct aggtattatg ctagc
+//

--- a/test/test_files/iGEM_SBOL2_imports_from_sbol3_direct.gb
+++ b/test/test_files/iGEM_SBOL2_imports_from_sbol3_direct.gb
@@ -1,0 +1,115 @@
+LOCUS       BBa_J23100                35 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  constitutive promoter family member..
+ACCESSION   BBa_J23100
+VERSION     BBa_J23100
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 ttgacggcta gctcagtcct aggtacagtg ctagc
+//
+LOCUS       BBa_J23102                35 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  constitutive promoter family member..
+ACCESSION   BBa_J23102
+VERSION     BBa_J23102
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 ttgacagcta gctcagtcct aggtactgtg ctagc
+//
+LOCUS       LmrA                     567 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  ..
+ACCESSION   LmrA
+VERSION     LmrA
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+ORIGIN
+        1 atgagctatg gtgatagccg tgaaaaaatt ctgagcgcag caacccgtct gtttcagctg
+       61 cagggttatt atggcaccgg tctgaatcag attatcaaag aaagcggtgc accgaaaggt
+      121 agcctgtatt atcattttcc gggtggtaaa gaacagctgg caattgaagc agtgaacgaa
+      181 atgaaagaat atatccgcca gaaaatcgcc gattgtatgg aagcatgtac cgatccggca
+      241 gaaggtattc aggcatttct gaaagaactg agctgtcagt ttagctgtac cgaagatatt
+      301 gaaggtctgc cggttggtct gctggcagca gaaaccagcc tgaaaagcga accgctgcgt
+      361 gaagcatgtc atgaagcata taaagaatgg gccagcgtgt atgaagaaaa actgcgtcag
+      421 accggttgta gcgaaagccg tgcaaaagaa gcaagcaccg ttgttaatgc aatgattgaa
+      481 ggtggtattc tgctgagcct gaccgcaaaa aatagcacac cgctgctgca tattagcagc
+      541 tgtattccgg atctgctgaa acgttaa
+//
+LOCUS       pSB1C3                  2070 bp    DNA     linear   UNK 01-JAN-1980
+DEFINITION  High copy BioBrick assembly plasmid..
+ACCESSION   pSB1C3
+VERSION     pSB1C3
+KEYWORDS    .
+SOURCE      .
+  ORGANISM  .
+            .
+FEATURES             Location/Qualifiers
+     misc_feature    1..21
+                     /label="BioBrick suffix"
+     stem_loop       2009..2012
+                     /label="end of terminator"
+     misc_feature    261..875
+                     /label="rep (pMB1)"
+     misc_feature    2051..2072
+                     /label="BioBrick prefix"
+     CDS             1160..1819
+                     /label="Chloramphenicol resistance"
+     stem_loop       1042..1147
+                     /label="T0 terminator"
+     primer_bind     1933..1952
+                     /label="Verification forward (VF2) primer binding site"
+     stem_loop       22..93
+                     /label="E. coli his operon terminator"
+     stem_loop       30..64
+                     /label="Stem loop"
+     misc_feature    276
+                     /label="ORI"
+     primer_bind     157..176
+                     /label="Verification reverse (VR) primer binding site"
+     stem_loop       2022..2041
+                     /label="Stem loop"
+ORIGIN
+        1 tactagtagc ggccgctgca gtccggcaaa aaagggcaag gtgtcaccac cctgcccttt
+       61 ttctttaaaa ccgaaaagat tacttcgcgt tatgcaggct tcctcgctca ctgactcgct
+      121 gcgctcggtc gttcggctgc ggcgagcggt atcagctcac tcaaaggcgg taatacggtt
+      181 atccacagaa tcaggggata acgcaggaaa gaacatgtga gcaaaaggcc agcaaaaggc
+      241 caggaaccgt aaaaaggccg cgttgctggc gtttttccac aggctccgcc cccctgacga
+      301 gcatcacaaa aatcgacgct caagtcagag gtggcgaaac ccgacaggac tataaagata
+      361 ccaggcgttt ccccctggaa gctccctcgt gcgctctcct gttccgaccc tgccgcttac
+      421 cggatacctg tccgcctttc tcccttcggg aagcgtggcg ctttctcata gctcacgctg
+      481 taggtatctc agttcggtgt aggtcgttcg ctccaagctg ggctgtgtgc acgaaccccc
+      541 cgttcagccc gaccgctgcg ccttatccgg taactatcgt cttgagtcca acccggtaag
+      601 acacgactta tcgccactgg cagcagccac tggtaacagg attagcagag cgaggtatgt
+      661 aggcggtgct acagagttct tgaagtggtg gcctaactac ggctacacta gaagaacagt
+      721 atttggtatc tgcgctctgc tgaagccagt taccttcgga aaaagagttg gtagctcttg
+      781 atccggcaaa caaaccaccg ctggtagcgg tggttttttt gtttgcaagc agcagattac
+      841 gcgcagaaaa aaaggatctc aagaagatcc tttgatcttt tctacggggt ctgacgctca
+      901 gtggaacgaa aactcacgtt aagggatttt ggtcatgaga ttatcaaaaa ggatcttcac
+      961 ctagatcctt ttaaattaaa aatgaagttt taaatcaatc taaagtatat atgagtaaac
+     1021 ttggtctgac agctcgaggc ttggattctc accaataaaa aacgcccggc ggcaaccgag
+     1081 cgttctgaac aaatccagat ggagttctga ggtcattact ggatctatca acaggagtcc
+     1141 aagcgagctc gatatcaaat tacgccccgc cctgccactc atcgcagtac tgttgtaatt
+     1201 cattaagcat tctgccgaca tggaagccat cacaaacggc atgatgaacc tgaatcgcca
+     1261 gcggcatcag caccttgtcg ccttgcgtat aatatttgcc catggtgaaa acgggggcga
+     1321 agaagttgtc catattggcc acgtttaaat caaaactggt gaaactcacc cagggattgg
+     1381 ctgagacgaa aaacatattc tcaataaacc ctttagggaa ataggccagg ttttcaccgt
+     1441 aacacgccac atcttgcgaa tatatgtgta gaaactgccg gaaatcgtcg tggtattcac
+     1501 tccagagcga tgaaaacgtt tcagtttgct catggaaaac ggtgtaacaa gggtgaacac
+     1561 tatcccatat caccagctca ccgtctttca ttgccatacg aaattccgga tgagcattca
+     1621 tcaggcgggc aagaatgtga ataaaggccg gataaaactt gtgcttattt ttctttacgg
+     1681 tctttaaaaa ggccgtaata tccagctgaa cggtctggtt ataggtacat tgagcaactg
+     1741 actgaaatgc ctcaaaatgt tctttacgat gccattggga tatatcaacg gtggtatatc
+     1801 cagtgatttt tttctccatt ttagcttcct tagctcctga aaatctcgat aactcaaaaa
+     1861 atacgcccgg tagtgatctt atttcattat ggtgaaagtt ggaacctctt acgtgcccga
+     1921 tcaactcgag tgccacctga cgtctaagaa accattatta tcatgacatt aacctataaa
+     1981 aataggcgta tcacgaggca gaatttcaga taaaaaaaat ccttagcttt cgctaaggat
+     2041 gatttctgga attcgcggcc gcttctagag
+//

--- a/test/test_files/iGEM_SBOL2_imports_from_sbol3_direct.gb
+++ b/test/test_files/iGEM_SBOL2_imports_from_sbol3_direct.gb
@@ -1,5 +1,5 @@
 LOCUS       BBa_J23100                35 bp    DNA     linear   UNK 01-JAN-1980
-DEFINITION  constitutive promoter family member..
+DEFINITION  constitutive promoter family member.
 ACCESSION   BBa_J23100
 VERSION     BBa_J23100
 KEYWORDS    .
@@ -11,7 +11,7 @@ ORIGIN
         1 ttgacggcta gctcagtcct aggtacagtg ctagc
 //
 LOCUS       BBa_J23102                35 bp    DNA     linear   UNK 01-JAN-1980
-DEFINITION  constitutive promoter family member..
+DEFINITION  constitutive promoter family member.
 ACCESSION   BBa_J23102
 VERSION     BBa_J23102
 KEYWORDS    .
@@ -23,7 +23,7 @@ ORIGIN
         1 ttgacagcta gctcagtcct aggtactgtg ctagc
 //
 LOCUS       LmrA                     567 bp    DNA     linear   UNK 01-JAN-1980
-DEFINITION  ..
+DEFINITION  .
 ACCESSION   LmrA
 VERSION     LmrA
 KEYWORDS    .
@@ -44,7 +44,7 @@ ORIGIN
       541 tgtattccgg atctgctgaa acgttaa
 //
 LOCUS       pSB1C3                  2070 bp    DNA     linear   UNK 01-JAN-1980
-DEFINITION  High copy BioBrick assembly plasmid..
+DEFINITION  High copy BioBrick assembly plasmid.
 ACCESSION   pSB1C3
 VERSION     pSB1C3
 KEYWORDS    .
@@ -54,28 +54,28 @@ SOURCE      .
 FEATURES             Location/Qualifiers
      misc_feature    1..21
                      /label="BioBrick suffix"
-     stem_loop       2009..2012
-                     /label="end of terminator"
-     misc_feature    261..875
-                     /label="rep (pMB1)"
-     misc_feature    2051..2072
-                     /label="BioBrick prefix"
-     CDS             1160..1819
-                     /label="Chloramphenicol resistance"
-     stem_loop       1042..1147
-                     /label="T0 terminator"
-     primer_bind     1933..1952
-                     /label="Verification forward (VF2) primer binding site"
      stem_loop       22..93
                      /label="E. coli his operon terminator"
      stem_loop       30..64
                      /label="Stem loop"
-     misc_feature    276
-                     /label="ORI"
      primer_bind     157..176
                      /label="Verification reverse (VR) primer binding site"
+     misc_feature    261..875
+                     /label="rep (pMB1)"
+     misc_feature    276
+                     /label="ORI"
+     stem_loop       1042..1147
+                     /label="T0 terminator"
+     CDS             1160..1819
+                     /label="Chloramphenicol resistance"
+     primer_bind     1933..1952
+                     /label="Verification forward (VF2) primer binding site"
+     stem_loop       2009..2012
+                     /label="end of terminator"
      stem_loop       2022..2041
                      /label="Stem loop"
+     misc_feature    2051..2072
+                     /label="BioBrick prefix"
 ORIGIN
         1 tactagtagc ggccgctgca gtccggcaaa aaagggcaag gtgtcaccac cctgcccttt
        61 ttctttaaaa ccgaaaagat tacttcgcgt tatgcaggct tcctcgctca ctgactcgct

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -70,19 +70,22 @@ class TestGenBankSBOL3(unittest.TestCase):
     def test_sbol3togb_1(self):
         """Test ability to convert from SBOL3 to GenBank using new converter"""
         # create tmp directory to store generated genbank file in for comparison
-        tmp_sub = copy_to_tmp(package=['BBa_J23101_from_genbank_to_sbol3_direct.nt'])
+        tmp_sub = copy_to_tmp(package=["BBa_J23101_from_genbank_to_sbol3_direct.nt"])
         doc3 = sbol3.Document()
-        doc3.read(os.path.join(tmp_sub, 'BBa_J23101_from_genbank_to_sbol3_direct.nt'))
-        # Get the SBOL3 test document path
-        SAMPLE_SBOL3_FILE_1 = (
-            Path(__file__).parent / "test_files" / "BBa_J23101_from_genbank_to_sbol3_direct.nt"
-        )
+        doc3.read(os.path.join(tmp_sub, "BBa_J23101_from_genbank_to_sbol3_direct.nt"))
         # Convert to GenBank and check contents
-        outfile = os.path.join(tmp_sub, 'BBa_J23101.gb')
-        self.converter.convert_sbol3_to_genbank(sbol3_file=str(SAMPLE_SBOL3_FILE_1), gb_file=outfile, write=True)
+        outfile = os.path.join(tmp_sub, "BBa_J23101.gb")
+        self.converter.convert_sbol3_to_genbank(
+            sbol3_file=None, doc=doc3, gb_file=outfile, write=True
+        )
         test_dir = os.path.dirname(os.path.realpath(__file__))
-        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_sbol3_direct.gb')
-        assert filecmp.cmp(outfile, comparison_file), f'Converted GenBank file {comparison_file} is not identical'
+        comparison_file = os.path.join(
+            test_dir, "test_files", "BBa_J23101_from_sbol3_direct.gb"
+        )
+        assert filecmp.cmp(
+            outfile, comparison_file
+        ), f"Converted GenBank file {comparison_file} is not identical"
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -70,18 +70,18 @@ class TestGenBankSBOL3(unittest.TestCase):
     def test_sbol3togb_1(self):
         """Test ability to convert from SBOL3 to GenBank using new converter"""
         # create tmp directory to store generated genbank file in for comparison
-        tmp_sub = copy_to_tmp(package=['BBa_J23101.nt'])
+        tmp_sub = copy_to_tmp(package=['BBa_J23101_from_genbank_to_sbol3_direct.nt'])
         doc3 = sbol3.Document()
-        doc3.read(os.path.join(tmp_sub, 'BBa_J23101.nt'))
+        doc3.read(os.path.join(tmp_sub, 'BBa_J23101_from_genbank_to_sbol3_direct.nt'))
         # Get the SBOL3 test document path
         SAMPLE_SBOL3_FILE_1 = (
-            Path(__file__).parent / "test_files" / "BBa_J23101.nt"
+            Path(__file__).parent / "test_files" / "BBa_J23101_from_genbank_to_sbol3_direct.nt"
         )
         # Convert to GenBank and check contents
         outfile = os.path.join(tmp_sub, 'BBa_J23101.gb')
         self.converter.convert_sbol3_to_genbank(sbol3_file=str(SAMPLE_SBOL3_FILE_1), gb_file=outfile, write=True)
         test_dir = os.path.dirname(os.path.realpath(__file__))
-        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101.gb')
+        comparison_file = os.path.join(test_dir, 'test_files', 'BBa_J23101_from_sbol3_direct.gb')
         assert filecmp.cmp(outfile, comparison_file), f'Converted GenBank file {comparison_file} is not identical'
 
 if __name__ == "__main__":

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -86,6 +86,25 @@ class TestGenBankSBOL3(unittest.TestCase):
             outfile, comparison_file
         ), f"Converted GenBank file {comparison_file} is not identical"
 
+    def test_sbol3togb_2(self):
+        """Test ability to convert from SBOL3 to GenBank with multiple records/features using new converter"""
+        # create tmp directory to store generated genbank file in for comparison
+        tmp_sub = copy_to_tmp(package=["iGEM_SBOL2_imports_from_genbank_to_sbol3_direct.nt"])
+        doc3 = sbol3.Document()
+        doc3.read(os.path.join(tmp_sub, "iGEM_SBOL2_imports_from_genbank_to_sbol3_direct.nt"))
+        # Convert to GenBank and check contents
+        outfile = os.path.join(tmp_sub, "iGEM_SBOL2_imports.gb")
+        self.converter.convert_sbol3_to_genbank(
+            sbol3_file=None, doc=doc3, gb_file=outfile, write=True
+        )
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        comparison_file = os.path.join(
+            test_dir, "test_files", "iGEM_SBOL2_imports_from_sbol3_direct.gb"
+        )
+        assert filecmp.cmp(
+            outfile, comparison_file
+        ), f"Converted GenBank file {comparison_file} is not identical"
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Changes:
* Newly added `convert_sbol3_to_genbank` method of the `GenBank_SBOL3_Converter` Class supports converting from sbol3 to Genbank file formats.
* Also, using the flag `--force-new-converter` through the `sbol2genbank` and `sbol-converter` will also now invoke the new method.
* Unit test `test_sbol3togb_1` has been added to test the conversion by directly invoking the new method.
* Unit test `test_genbank_conversion_new_converter` has been added to test the conversion by invoking it from the console script, using the previously added flag `--force-new-converter.`
* 2 New Test files: `BBa_J23101_from_sbol3_direct.gb` and `iGEM_SBOL2_imports_from_sbol3_direct.gb` has been added to aid the above 2 unit tests.

### Update:
1. Throws ValueError when the sbol3 component has more than 1 sequence. (TODO: Use more specific ErrorClass later)
2. The converter used to pick up features from a sbol3 Component in random order every time the conversion was called, leading to different file outputs each time. We discussed this in our last meeting, and I have implemented a lexicographic sorting of features of each component based on the feature location's start and endpoints. This ensures the output stays the same always for a specific input sbol3 document.
3. I have made the logger throw warnings to the console whenever, a feature translation lookup does not have any row in the CSV with the role in the given SBOL3/GenBank feature. The logger warns the user of this and mentions the default ontology term it will be using.

### Clarification Needed:
- [x]  Regarding update 1.; I have made the sequence object required while defining a BioPython `SeqRecord` class as `None` when a component does not have a sequence. Is this fine?
    * Moved to https://github.com/SynBioDex/SBOL-utilities/issues/147
- [ ] Regarding update 2.; There may be multiple feature locations for every feature; in this case, how should the sorting be implemented? Currently, it just sorts features based on the start/end points assuming there is only 1 location.
    * Moved to https://github.com/SynBioDex/SBOL-utilities/issues/148
- [x] Resolvement of [this issue](https://github.com/SynBioDex/SBOL-utilities/issues/146).
- [ ] We decided to store the `VERSION` annotation for GenBank records as "1" by default for now since the extra annotation fields are not currently stored in SBOL3 files during conversion from GenBank to SBOL3. However, this does not seem to reflect in converted GenBank files (the file shows no difference in the `VERSION` field, even after specifying it during the record's creation). 
    * I think this is covered by https://github.com/SynBioDex/SBOL-utilities/issues/150. If not, a new issue should be opened specifically for the VERSION field.


## TODO:

- [ ] A point was brought up in the last discussion to remove the `write` argument altogether in both the directions of conversion and have the logic implemented separately. We would need to discuss the details of its implementation.
- [ ] Also, I learned that features of type `SubComponents` in SBOL3 components would also need to be stored in the GenBank file. Currently, the converter ignores all features other than `SequenceFeature` while converting to GenBank. This would again need some discussion to implement.
- [ ] There can also be multiple feature locations, but it turns out storing multiple feature locations for a single GenBank feature is not that straightforward. SBOL3 allows for a simple way to store locations in an array, but doing something similar for GenBank will be required too.