### PR TITLE
add: support for remaining iGEM testsuite files

### DIFF
--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -34,9 +34,6 @@ class GenBank_SBOL3_Converter:
     DEFAULT_GB_TERM = "misc_feature"
     # Namespace to be used be default if not provided, and also for all unit tests related to this converter
     TEST_NAMESPACE = "https://test.sbol3.genbank/"
-    CUSTOM_REFERENCE_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#reference"
-    FEATURE_QUALIFIER_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#featureQualifier"
-    CUSTOM_STRUCTURED_COMMENT_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#structured_comment"
     # File locations for required CSV data files which store the ontology term translations between GenBank and SO ontologies
     GB2SO_MAPPINGS_CSV = os.path.join(os.path.dirname(os.path.realpath(__file__)), "gb2so.csv")
     SO2GB_MAPPINGS_CSV = os.path.join(os.path.dirname(os.path.realpath(__file__)), "so2gb.csv")
@@ -96,9 +93,9 @@ class GenBank_SBOL3_Converter:
         # the SBOL3 parser to build objects with a Component type URI
         sbol3.Document.register_builder(sbol3.SBOL_COMPONENT, build_component_genbank_extension)
         # Register the buildre function for custom reference properties
-        sbol3.Document.register_builder(self.CUSTOM_REFERENCE_PROPERTY_URI, build_custom_reference_property)
+        sbol3.Document.register_builder(self.Feature_GenBank_Extension.GENBANK_FEATURE_QUALIFIER_NS, build_custom_reference_property)
         # Register the buildre function for custom structured comment properties
-        sbol3.Document.register_builder(self.CUSTOM_STRUCTURED_COMMENT_PROPERTY_URI, build_custom_structured_comment_property)
+        sbol3.Document.register_builder(self.CustomStructuredCommentProperty.CUSTOM_STRUCTURED_COMMENT_NS, build_custom_structured_comment_property)
         # # Register the builder function so it can be invoked by
         # # the SBOL3 parser to build objects with a SequenceFeature type URI
         sbol3.Document.register_builder(sbol3.SBOL_SEQUENCE_FEATURE, build_feature_qualifiers_extension)
@@ -318,7 +315,7 @@ class GenBank_SBOL3_Converter:
         # create dict to link component with their respective Reference property objects
         references: Dict[sbol3.Component, List[sbol3.CustomTopLevel]] = {}
         for obj in doc.objects:  
-            if isinstance(obj, sbol3.CustomTopLevel) and obj.type_uri == self.CUSTOM_REFERENCE_PROPERTY_URI:
+            if isinstance(obj, sbol3.CustomTopLevel) and obj.type_uri == self.CustomReferenceProperty.CUSTOM_REFERENCE_NS:
                 component_object = doc.find(str(obj.component))
                 if component_object and isinstance(component_object, sbol3.Component):
                     references[component_object] = [obj] if component_object not in references else references[component_object] + [obj]
@@ -327,7 +324,7 @@ class GenBank_SBOL3_Converter:
         # create dict to link component with their respective structured comment objects
         structured_comments: Dict[sbol3.Component, List[sbol3.CustomTopLevel]] = {}
         for obj in doc.objects:  
-            if isinstance(obj, sbol3.CustomTopLevel) and obj.type_uri == self.CUSTOM_STRUCTURED_COMMENT_PROPERTY_URI:
+            if isinstance(obj, sbol3.CustomTopLevel) and obj.type_uri == self.CustomStructuredCommentProperty.CUSTOM_STRUCTURED_COMMENT_NS:
                 component_object = doc.find(str(obj.component))
                 if component_object and isinstance(component_object, sbol3.Component):
                     structured_comments[component_object] = [obj] if component_object not in structured_comments else structured_comments[component_object] + [obj]

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -176,6 +176,7 @@ class GenBank_SBOL3_Converter:
             self.genbank_topology      = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#topology"   , 0, 1)
             self.genbank_gi            = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#gi"         , 0, 1)
             self.genbank_comment       = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#comment"    , 0, 1)
+            self.genbank_dblink        = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#dbxrefs"    , 0, 1)
             self.genbank_record_id     = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#id"         , 0, 1)
             # TODO : add note linking issue here
             self.genbank_taxonomy      = sbol3.TextProperty(self, f"{self.GENBANK_EXTRA_PROPERTY_NS}#taxonomy"   , 0, 1)
@@ -399,6 +400,9 @@ class GenBank_SBOL3_Converter:
         :param record: GenBank SeqRecord instance for the record which contains extra properties
         """
         comp.genbank_record_id = record.id
+        # set dblinks from the dbxrefs property of biopython
+        if record.dbxrefs:
+            comp.genbank_dblink = "::".join(record.dbxrefs)
         for annotation in record.annotations:
             # Sending out warnings for genbank info not storeable in sbol3
             logging.warning(
@@ -504,6 +508,9 @@ class GenBank_SBOL3_Converter:
         """
         if isinstance(obj, self.Component_GenBank_Extension):
             seq_rec.id = obj.genbank_record_id
+            # set db links using dbxrefs property of biopython
+            if obj.genbank_dblink:
+                seq_rec.dbxrefs = str(obj.genbank_dblink).split("::")
             # 1. GenBank Record Date
             seq_rec.annotations['date'] = obj.genbank_date
             # 2. GenBank Record Division

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -33,6 +33,7 @@ class GenBank_SBOL3_Converter:
     DEFAULT_GB_TERM = "misc_feature"
     # Namespace to be used be default if not provided, and also for all unit tests related to this converter
     TEST_NAMESPACE = "https://test.sbol3.genbank/"
+    CUSTOM_COMMENT_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#comment"
     CUSTOM_REFERENCE_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#reference"
     FEATURE_QUALIFIER_PROPERTY_URI = "http://www.ncbi.nlm.nih.gov/genbank#featureQualifier"
     # File locations for required CSV data files which store the ontology term translations between GenBank and SO ontologies
@@ -81,11 +82,22 @@ class GenBank_SBOL3_Converter:
             obj = self.CustomReferenceProperty(identity=identity, type_uri=type_uri)
             return obj
 
+        def build_custom_comment_property(*, identity, type_uri) -> GenBank_SBOL3_Converter.CustomCommentProperty:
+            """A builder function to be called by the SBOL3 parser
+            when it encounters a CustomCommentProperty Toplevel object in an SBOL file.
+            :param identity: identity for custom comment property instance to have
+            :param type_uri: type_uri for custom comment property instance to have
+            """
+            obj = self.CustomCommentProperty(identity=identity, type_uri=type_uri)
+            return obj
+
         # Register the builder function so it can be invoked by
         # the SBOL3 parser to build objects with a Component type URI
         sbol3.Document.register_builder(sbol3.SBOL_COMPONENT, build_component_genbank_extension)
         # Register the buildre function for custom reference properties
         sbol3.Document.register_builder(self.CUSTOM_REFERENCE_PROPERTY_URI, build_custom_reference_property)
+        # Register the buildre function for custom comment properties
+        sbol3.Document.register_builder(self.CUSTOM_COMMENT_PROPERTY_URI, build_custom_comment_property)
         # # Register the builder function so it can be invoked by
         # # the SBOL3 parser to build objects with a SequenceFeature type URI
         sbol3.Document.register_builder(sbol3.SBOL_SEQUENCE_FEATURE, build_feature_qualifiers_extension)
@@ -111,6 +123,22 @@ class GenBank_SBOL3_Converter:
             # TODO: support cut locations?
             # there can be multiple locations described for a reference, thus upper bound needs to be > 1 in order to use ListProperty
             self.location = sbol3.OwnedObject(self, f"{self.CUSTOM_REFERENCE_NS}#location", 0, math.inf, type_constraint=sbol3.Range)
+
+
+    class CustomCommentProperty(sbol3.CustomTopLevel):
+        """Serves to store information and annotations for 'Comment' objects in 
+        GenBank file to SBOL3 while parsing so that it may be retrieved back in a round trip
+        :extends: sbol3.CustomTopLevel class
+        """
+        CUSTOM_REFERENCE_NS = "http://www.ncbi.nlm.nih.gov/genbank#comment"
+        def __init__(self, type_uri=CUSTOM_REFERENCE_NS, identity="customCommentProperty"):
+            super().__init__(identity, type_uri)
+            self.text       = sbol3.TextProperty(self, f"{self.CUSTOM_REFERENCE_NS}#text"      , 0, 1)
+            # stores the display id of parent component for a particular CustomReferenceProperty object
+            self.component  = sbol3.TextProperty(self, f"{self.CUSTOM_REFERENCE_NS}#component" , 0, 1)
+            # there can be multiple key/values described for a structured_comment, thus upper bound needs to be > 1 in order to use ListProperty
+            self.structured_keys   = sbol3.TextProperty(self, f"{self.CUSTOM_REFERENCE_NS}#structuredKeys", 0, math.inf)
+            self.structured_values = sbol3.TextProperty(self, f"{self.CUSTOM_REFERENCE_NS}#structuredValues", 0, math.inf)
 
 
     class Feature_GenBank_Extension(sbol3.SequenceFeature):
@@ -293,6 +321,17 @@ class GenBank_SBOL3_Converter:
                     references[component_object] = [obj] if component_object not in references else references[component_object] + [obj]
                 # TODO: Raise error here
                 # else:
+        # create dict to link component with their respective comment objects
+        comments: Dict[sbol3.Component, sbol3.CustomTopLevel] = {}
+        for obj in doc.objects:  
+            if isinstance(obj, sbol3.CustomTopLevel) and obj.type_uri == self.CUSTOM_COMMENT_PROPERTY_URI:
+                component_object = doc.find(str(obj.component))
+                if component_object and isinstance(component_object, sbol3.Component):
+                    comments[component_object] = obj
+                    # comments[component_object] = [obj] if component_object not in comments else references[component_object] + [obj]
+                # TODO: Raise error here
+                # else:
+
         # create updated py dict to store mappings between gb and so ontologies
         map_created = self.create_GB_SO_role_mappings(
             so2gb_csv=self.SO2GB_MAPPINGS_CSV, convert_gb2so=False
@@ -331,7 +370,7 @@ class GenBank_SBOL3_Converter:
                     name=obj.display_id,
                 )
                 # Resetting extraneous genbank properties from extended component-genbank class
-                self._reset_extra_properties_in_genbank(obj, seq_rec, references)
+                self._reset_extra_properties_in_genbank(obj, seq_rec, references, comments)
 
                 seq_rec_features = []
                 # recreate all sequence features, and tag all encountered feature qualifiers via extended Feature_GenBank_Extension class
@@ -375,7 +414,6 @@ class GenBank_SBOL3_Converter:
                 else: comp.genbank_division = record.annotations['data_file_division']
             # 3. GenBank Record Keywords
             elif annotation == 'keywords':
-                # comp.genbank_keywords = sorted(record.annotations['keywords'])
                 comp.genbank_keywords = ",".join(record.annotations['keywords'])
             # 4. GenBank Record Molecule Type
             elif annotation == 'molecule_type':
@@ -392,6 +430,16 @@ class GenBank_SBOL3_Converter:
             # 8. GenBank Record Topology
             elif annotation == 'topology':
                 comp.genbank_topology = record.annotations['topology']
+            # 14. GenBank Record Comment
+            elif annotation == 'comment':
+                comment_object = self.CustomCommentProperty(identity = comp.identity + f"/Comment")
+                comment_object.text = record.annotations['comment']
+                if comp.display_id:
+                    comment_object.component = comp.display_id
+                doc.add(comment_object)
+            # 15. GenBank Record Structured comments
+            elif annotation == 'structured_comment':
+                pass
             # 9. GenBank Record GI Property
             elif annotation == 'gi':
                 comp.genbank_gi = record.annotations['gi']
@@ -436,7 +484,7 @@ class GenBank_SBOL3_Converter:
         comp.genbank_locus = record.name
 
 
-    def _reset_extra_properties_in_genbank(self, obj: sbol3.Component, seq_rec: SeqRecord, references: Dict[sbol3.Component, List[sbol3.CustomTopLevel]]) -> None:
+    def _reset_extra_properties_in_genbank(self, obj: sbol3.Component, seq_rec: SeqRecord, references: Dict[sbol3.Component, List[sbol3.CustomTopLevel]], comments: Dict[sbol3.Component, sbol3.CustomTopLevel]) -> None:
         """Helper function for resetting properties for GenBank's extraneous properties from SBOL3 Document's properties,
         by using a modified, extended SBOL3 Component class, and a new CustomReferenceProperty TopLevel class.
         :param obj: SBOL3 component, extra properties would be stored within it if its an instance of the extended SBOL3 Component class
@@ -475,6 +523,18 @@ class GenBank_SBOL3_Converter:
             seq_rec.annotations['accessions'] = sorted(list(obj.genbank_accessions))
             # 11. GenBank Sequence Version
             seq_rec.annotations['sequnce_version'] = obj.genbank_seq_version
+            # 14. GenBank Record Comments
+            if obj in comments:
+                # if sbol3 object has comment
+                record_comment = ""
+                record_comment = comments[obj].text
+                seq_rec.annotations['comment'] = record_comment
+            # 15. GenBank Record Structured Comments
+            # if obj in comments:
+            #     # if sbol3 object has comment
+            #     record_comment = ""
+            #     record_comment = comments[obj].text
+            #     seq_rec.annotations['comment'] = record_comment
             # 12. GenBank Record References
             if obj in references:
                 # if sbol3 object has references

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -709,9 +709,9 @@ class GenBank_SBOL3_Converter:
                 # sort feature locations lexicographically internally first
                 # NOTE: If the feature location has an outer "complement" location operator, the sort needs to be in reverse order
                 if obj_feat.orientation == sbol3.SO_REVERSE:
-                    feat_loc_parts.sort(key=lambda loc: (loc.start, loc.end), reverse=True)
+                    feat_loc_parts.sort(key=lambda loc: (loc.start, loc.end, loc.strand), reverse=True)
                 else:
-                    feat_loc_parts.sort(key=lambda loc: (loc.start, loc.end))
+                    feat_loc_parts.sort(key=lambda loc: (loc.start, loc.end, loc.strand))
                 for loc in feat_loc_parts:
                     feat_loc_positions += [loc.start, loc.end]
                 if len(feat_loc_parts) > 1:
@@ -750,5 +750,5 @@ class GenBank_SBOL3_Converter:
                         feat.qualifiers[keys[qualifier_ind].split(":", 1)[1]] = values[qualifier_ind].split(":", 1)[1]
                 seq_rec_features.append(feat)
         # Sort features based on feature location start/end, lexicographically
-        seq_rec_features.sort(key=lambda feat: feat_order[feat])
+        seq_rec_features.sort(key=lambda feat: (feat_order[feat], feat.strand, len(feat.qualifiers), feat.type))
         seq_rec.features = seq_rec_features

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -93,7 +93,7 @@ class GenBank_SBOL3_Converter:
         # the SBOL3 parser to build objects with a Component type URI
         sbol3.Document.register_builder(sbol3.SBOL_COMPONENT, build_component_genbank_extension)
         # Register the buildre function for custom reference properties
-        sbol3.Document.register_builder(self.Feature_GenBank_Extension.GENBANK_FEATURE_QUALIFIER_NS, build_custom_reference_property)
+        sbol3.Document.register_builder(self.CustomReferenceProperty.CUSTOM_REFERENCE_NS, build_custom_reference_property)
         # Register the buildre function for custom structured comment properties
         sbol3.Document.register_builder(self.CustomStructuredCommentProperty.CUSTOM_STRUCTURED_COMMENT_NS, build_custom_structured_comment_property)
         # # Register the builder function so it can be invoked by
@@ -126,6 +126,7 @@ class GenBank_SBOL3_Converter:
     class CustomStructuredCommentProperty(sbol3.CustomTopLevel):
         """Serves to store information and annotations for 'Structured_Comment' objects in 
         GenBank file to SBOL3 while parsing so that it may be retrieved back in a round trip
+        Complete reference available at: https://www.ncbi.nlm.nih.gov/genbank/structuredcomment/
         :extends: sbol3.CustomTopLevel class
         """
         CUSTOM_STRUCTURED_COMMENT_NS = "http://www.ncbi.nlm.nih.gov/genbank#structured_comment"
@@ -399,6 +400,9 @@ class GenBank_SBOL3_Converter:
         comp.genbank_record_id = record.id
         # set dblinks from the dbxrefs property of biopython
         if record.dbxrefs:
+            # dbxrefs are parsed in a list by biopython from `record.dbxrefs`; we are storing them as a flat string
+            # so as to maintain order. Thus, we are creating a custom delimetere of `::`, by which we shall seperate
+            # individual dbxrefs in the string and later split them to a list while resetting them in genbank
             comp.genbank_dblink = "::".join(record.dbxrefs)
         for annotation in record.annotations:
             # Sending out warnings for genbank info not storeable in sbol3
@@ -507,6 +511,9 @@ class GenBank_SBOL3_Converter:
             seq_rec.id = obj.genbank_record_id
             # set db links using dbxrefs property of biopython
             if obj.genbank_dblink:
+                # NOTE: see comment on `_store_extra_properties_in_sbol3`'s dbxrefs section, wherein we describe how '::' 
+                # is used as a delimeter to store the dbxrefs list as a string to maintain order. Here, we split the string 
+                # by the same delimeter to restore the list in resetting GenBank properties.
                 seq_rec.dbxrefs = str(obj.genbank_dblink).split("::")
             # 1. GenBank Record Date
             seq_rec.annotations['date'] = obj.genbank_date

--- a/test/test_files/sbol3_genbank_conversion/test_dblink_property.gb
+++ b/test/test_files/sbol3_genbank_conversion/test_dblink_property.gb
@@ -1,0 +1,223 @@
+LOCUS       JWYZ01000115            3242 bp    DNA     linear   BCT 16-JAN-2015
+DEFINITION  Escherichia coli strain CVM N37069PS N37069PS_contig_115, whole
+            genome shotgun sequence.
+ACCESSION   JWYZ01000115
+VERSION     JWYZ01000115.1
+DBLINK      BioProject: PRJNA266657
+            BioSample: SAMN03177677
+KEYWORDS    WGS.
+SOURCE      Escherichia coli
+  ORGANISM  Escherichia coli
+            Bacteria; Proteobacteria; Gammaproteobacteria; Enterobacterales;
+            Enterobacteriaceae; Escherichia.
+REFERENCE   1  (bases 1 to 3242)
+  AUTHORS   Tyson,G.H., McDermott,P.F., Li,C., Chen,Y., Tadesse,D.A.,
+            Mukherjee,S., Bodeis-Jones,S., Kabera,C., Gaines,S.A.,
+            Loneragan,G.H., Edrington,T.S., Torrence,M., Harhay,D.M. and Zhao,S.
+  TITLE     WGS accurately predicts antimicrobial resistance in Escherichia coli
+  JOURNAL   J. Antimicrob. Chemother. 70 (10), 2763-2769 (2015)
+   PUBMED   26142410
+REFERENCE   2  (bases 1 to 3242)
+  AUTHORS   Tyson,G.H., McDermott,P.F., Li,C., Tadesse,D.A., Mukherjee,S.,
+            Bodeis-Jones,S., Kabera,C., Gaines,S.A., Loneragan,G.H.,
+            Edrington,T.S., Torrence,M., Harhay,D.M. and Zhao,S.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (17-NOV-2014) CVM, FDA, 8401 Muirkirk Rd, Laurel, MD
+            20708, USA
+COMMENT     ##Genome-Assembly-Data-START##
+            Assembly Method              :: CLC Genomics Workbench v. 7.5
+            Assembly Name                :: Escherichia coli CVM N37069PS v1.0
+            Genome Coverage              :: 48.5x
+            Sequencing Technology        :: Illumina MiSeq
+            ##Genome-Assembly-Data-END##
+            ##Genome-Annotation-Data-START##
+            Annotation Provider          :: NCBI
+            Annotation Date              :: 12/29/2014 14:07:05
+            Annotation Pipeline :: NCBI Prokaryotic Genome Annotation Pipeline
+            Annotation Method :: Best-placed reference protein set; GeneMarkS+
+            Annotation Software revision :: 2.9 (rev. 455303)
+            Features Annotated :: Gene; CDS; rRNA; tRNA; ncRNA; repeat_region
+            Genes                        :: 4,855
+            CDS                          :: 4,642
+            Pseudo Genes                 :: 107
+            CRISPR Arrays                :: 2
+            rRNAs                        :: 11 (5S, 16S, 23S)
+            tRNAs                        :: 78
+            ncRNA                        :: 17
+            Frameshifted Genes           :: 41
+            ##Genome-Annotation-Data-END##
+            Annotation was added by the NCBI Prokaryotic Genome Annotation
+            Pipeline (released 2013). Information about the Pipeline can be
+            found here: http://www.ncbi.nlm.nih.gov/genome/annotation_prok/
+FEATURES             Location/Qualifiers
+     gene            complement(1..115)
+                     /locus_tag="PU64_23660"
+     CDS             complement(1..115)
+                     /locus_tag="PU64_23660"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_005059815.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="pyrBI operon leader peptide"
+                     /protein_id="KIG36579.1"
+                     /translation="MVQCVRHFVLPRLKKDAGLPFFFPLITHSQPLNRGAFF"
+     source          1..3242
+                     /organism="Escherichia coli"
+                     /mol_type="genomic DNA"
+                     /submitter_seqid="N37069PS_contig_115"
+                     /strain="CVM N37069PS"
+                     /isolation_source="Farm"
+                     /db_xref="taxon:562"
+                     /country="USA"
+                     /collection_date="20-Jan-2012"
+     gene            95..427
+                     /locus_tag="PU64_23665"
+     CDS             95..427
+                     /locus_tag="PU64_23665"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_001349257.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="hypothetical protein"
+                     /protein_id="KIG36585.1"
+                     /translation="MSNTLNHTSSRQIVRHYTHRQKRRKHLMQYFVSANGLFELKVKVY
+                     AFLFDVILQGNCPSVSIIADIPCFFLFHFHAIRYAFYSIHPTYRAECESERLTLLLTAQ
+                     GCALSL"
+     gene            complement(396..791)
+                     /locus_tag="PU64_23670"
+     CDS             complement(396..791)
+                     /locus_tag="PU64_23670"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_001701843.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mRNA endoribonuclease"
+                     /protein_id="KIG36580.1"
+                     /translation="MVERTAVFPAGRHSLYAEHRYSAAIRSGDLLFVSGQVGSREDGTP
+                     EPDFQQQVRLAFDNLHATLAAAGCTFDDIIDVTSFHTDPENQFEDIMTVKNEIFSAPPY
+                     PNWTAVGVTWLAGFDFEIKVIARIPEQ"
+     gene            complement(922..1635)
+                     /locus_tag="PU64_23675"
+     CDS             complement(922..1635)
+                     /locus_tag="PU64_23675"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:SwissProt:P39333.2"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="oxidoreductase"
+                     /protein_id="KIG36581.1"
+                     /translation="MGAFTGKTVLILGGSRGIGAAIVRRFVTDGANVRFTYAGSKDAAK
+                     RLAQETGATAVFTDSADRDAVIDVVRKSGALDILVVNAGIGVFGEALELNADDIDRLFK
+                     INIHAPYHASVEAARQMPEGGRILIIGSVNGDRMPVAGMAAYAASKSALQGMARGLARD
+                     FGPRGITINVVQPGPIDTDANPANGPMRDMLHSLMAIKRHGQPEEVAGMVAWLAGPEAS
+                     FVTGAMHTIDGAFGA"
+     gene            1706..2299
+                     /locus_tag="PU64_23680"
+     CDS             1706..2299
+                     /locus_tag="PU64_23680"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_001544295.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="TetR family transcriptional regulator"
+                     /protein_id="KIG36582.1"
+                     /translation="MVTKKQSRVPGRPRRFAPEQAISAAKVLFHQKGFDAVSVAEVTDY
+                     LGINPPSLYAAFGSKAGLFSRVLNEYVGTEAIPLADILRDDRPVGECLVEVLKEAARRY
+                     SQNGGCAGCMVLEGIHSHDPLARDIAVQYYHAAETTIYDYIARRHPQSAQCVTDFMSTV
+                     MSGLSAKAREGHSIEQLCATAALAGEAIKTLLKE"
+     gene            2444..2896
+                     /locus_tag="PU64_23685"
+     CDS             2444..2896
+                     /locus_tag="PU64_23685"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_001570607.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="toxin-antitoxin biofilm protein TabA"
+                     /protein_id="KIG36583.1"
+                     /translation="MIIGNIHNLQPWLPQELRQAIEHIKAHVTAETPKGKHDIEGNHLF
+                     YLISEDMTEPYEARRAEYHARYLDIQIVLKGQEGMTFSTQPAGTPDTDWLADKDIAFLP
+                     EGVDEKTVILNEGDFVVFYPGEVHKPLCAVGAPAQVRKAVVKMLMA"
+     gene            3019..3242
+                     /locus_tag="PU64_23690"
+     CDS             3019..3242
+                     /locus_tag="PU64_23690"
+                     /inference="EXISTENCE: similar to AA
+                     sequence:RefSeq:WP_000036524.1"
+                     /note="Derived by automated computational analysis using
+                     gene prediction method: Protein Homology."
+                     /codon_start=1
+                     /transl_table=11
+                     /product="DNA-binding protein"
+                     /protein_id="KIG36584.1"
+                     /translation="MSKISGWNFSQNITSADNCKQKNEDLDTWYVGMNDFARIAGGQNS
+                     RSNILSPRAFLEFLAKIFTLGYVDFSKRS"
+ORIGIN
+        1 aaaaaaaagc ccctcgattg aggggctggg aatgggtgat caacgggaag aaaaacggca
+       61 ggccagcgtc ttttttcaga cgcggtaaga caaaatgtcg aacacactga accatacatc
+      121 ctcccggcaa attgtccggc attatactca tcgtcagaag cggcgcaagc atttgatgca
+      181 atattttgtc agcgcaaacg gtttatttga attaaaagtc aaggtatatg catttttatt
+      241 tgatgtgatt ctgcagggga actgtccttc ggtatcaata attgcagaca ttccctgctt
+      301 tttccttttt cactttcacg caatcagata tgcattttat tccattcatc cgacttatag
+      361 ggcggagtgt gaaagcgaac ggctaacact attgcttact gctcagggat gcgcgctatc
+      421 actttaattt caaaatcaaa gcctgccagc catgtaacac ccaccgccgt ccagtttgga
+      481 taaggtgggg cgctaaatat ttcatttttc accgtcatga tgtcttcaaa ttggttttct
+      541 ggatcggtat ggaagctcgt aacatcaatg atatcgtcaa aagtgcatcc cgcagctgcc
+      601 agggtcgcat gcaaattatc aaatgccagt ctgacttgtt gctgaaaatc gggttctggt
+      661 gttccgtcct ctcgacttcc tacttgcccg gaaacaaaca gcaaatcgcc ggaacgaata
+      721 gccgcagaat aacgatgctc agcatatagt gaatgtcggc cagcagggaa aacagcggtt
+      781 ctttctacca tttggttatc ctcaagattt acgacatgaa cagaagattt ctctttaccg
+      841 ggagccgctt ttagcggacg acgtgagtaa acaaaaccca gacatcatgg ataatggctg
+      901 ggcttaattg agcgtagtcg gttatgcgcc aaacgcgcca tcaatggtat gcattgcgcc
+      961 ggtaacaaaa ctggcttctg gccctgctaa ccatgcgacc ataccagcga cctcttccgg
+     1021 ttgcccatgt cttttgatag ccatcaaact atgcaacata tcgcgcattg gcccgttggc
+     1081 gggattagcg tcggtatcaa ttggccctgg ctggacgacg ttaatggtga tcccacgcgg
+     1141 tccaaaatca cgggccagcc cgcgcgccat gccttgcagg gcagatttgc tggcggcata
+     1201 agcagccatg cctgcaacag gcatacgatc gccattcacg gagccgatga ttaagatgcg
+     1261 cccgccttcg ggcatctgcc gggcggcttc aacagaggca tgataaggag catgaatatt
+     1321 gattttgaaa aggcgatcaa tatcgtcggc atttaattcc agggcctcgc caaagacgcc
+     1381 aatacctgca tttaccacca ggatatccaa tgcgccgctc ttacgaacga catcaatgac
+     1441 agcgtctctg tcagcactat ctgtgaatac tgctgtcgct ccagtctctt gtgccaggcg
+     1501 tttagcggca tctttcgacc ccgcataggt gaatcgtaca ttggccccat cggtgacgaa
+     1561 acgacgtacg atagcggcac cgataccacg actgccaccg aggatgagaa ctgtcttacc
+     1621 tgtaaaagcg cccataagga ctccttgatt tattatgtaa catgcattac aaaactgttt
+     1681 taactttctg tcaacatgtt ttgtaatggt cactaaaaaa caatctcgcg ttccaggtcg
+     1741 tcccagacgt ttcgctcctg agcaggcaat ctctgcggca aaagtgcttt ttcaccaaaa
+     1801 aggtttcgat gctgtcagtg ttgctgaagt tactgattat cttggtatta accccccgag
+     1861 cctctacgcg gcttttggca gtaaagctgg gttatttagc cgtgtactca atgaatacgt
+     1921 cggtacggaa gctattccgc ttgccgatat tcttcgtgat gatcgtccag taggcgagtg
+     1981 cctggttgag gtattaaaag aagcggcgcg cagatatagc caaaacggcg gctgcgctgg
+     2041 ctgtatggtt cttgaaggta ttcatagtca tgatccacta gcgcgtgata ttgccgttca
+     2101 atattatcac gccgcagaaa cgaccattta tgactatatc gccaggcggc atccacaaag
+     2161 cgcacaatgt gtgactgatt ttatgagtac cgtgatgtca gggctttctg cgaaggcacg
+     2221 ggaggggcac tcaatcgaac aactctgtgc aacagctgca ctggcggggg aagcgataaa
+     2281 aactcttctc aaggagtgat gctggccttg atccgaaagg cgggaacgcg cctgccgata
+     2341 agttgtgata agacaataat tcacgcatta aggctagcgg aattgatcat cttttcgtat
+     2401 aacgatagaa atgaaacgtt gttttaatta aggagtggaa aagatgatca tcggaaatat
+     2461 tcataatctt cagccgtggc taccccagga gttacgccag gcgattgagc atatcaaagc
+     2521 acacgttacg gcagaaacgc caaagggcaa gcacgatatc gaaggcaatc atctgtttta
+     2581 tcttatctcg gaagatatga ccgagccgta cgaagcccgc cgtgcggagt accatgcccg
+     2641 ctatctcgac attcagattg tgttaaaagg tcaggaaggc atgaccttca gcacgcaacc
+     2701 tgcaggcacg ccggataccg actggttagc tgataaagac atcgcatttt tgccggaagg
+     2761 cgttgatgag aaaacagtta tccttaatga aggtgatttt gttgtgtttt atccggggga
+     2821 agtgcataaa ccgctgtgcg cagtgggtgc accagcccag gttcgcaaag cagtagtgaa
+     2881 gatgctgatg gcgtgatgac ttttcgccgt aaataactcc aggtttacgg cgagtttgtg
+     2941 aaaagagcgt tttttgatat ttttttgtga gtaaaatttg taatgcttag acgttcttat
+     3001 taactcaagg agtccgtcat gagcaaaata tcaggttgga atttttctca aaacattaca
+     3061 tcagccgaca attgtaaaca aaaaaatgaa gacttagata cctggtatgt gggaatgaat
+     3121 gattttgccc gaattgccgg agggcagaat agcagaagca atattctttc tcccagagca
+     3181 tttttggagt ttttggctaa gatatttacc ctgggttatg tggattttag caaacgctcc
+     3241 aa
+//

--- a/test/test_files/sbol3_genbank_conversion/test_structured_comments.gb
+++ b/test/test_files/sbol3_genbank_conversion/test_structured_comments.gb
@@ -20,12 +20,12 @@ COMMENT     ##Assembly-Data-START##
             Sequencing Technology :: Sanger dideoxy sequencing
             ##Assembly-Data-END##
 FEATURES             Location/Qualifiers
+     gene            1..720
+                     /gene="cpmCerulean3"
      source          1..720
                      /organism="synthetic construct"
                      /mol_type="other DNA"
                      /db_xref="taxon:32630"
-     gene            1..720
-                     /gene="cpmCerulean3"
      CDS             1..720
                      /gene="cpmCerulean3"
                      /note="enhanced cyan fluorescent protein; codon-optimized

--- a/test/test_files/sbol3_genbank_conversion/test_structured_comments.gb
+++ b/test/test_files/sbol3_genbank_conversion/test_structured_comments.gb
@@ -1,0 +1,56 @@
+LOCUS       KY484012                 720 bp    DNA     linear   SYN 01-NOV-2017
+DEFINITION  Synthetic construct mCerulean3 (cpmCerulean3) gene, complete cds.
+ACCESSION   KY484012
+VERSION     KY484012.1
+KEYWORDS    .
+SOURCE      synthetic construct
+  ORGANISM  synthetic construct
+            other sequences; artificial sequences.
+REFERENCE   1  (bases 1 to 720)
+  AUTHORS   Boehm,C.R., Gorchs Rovira,A. and Mehrshahi,P.
+  TITLE     Implementation of a synthetic transcriptional and gate in the
+            chloroplast of Chlamydomonas reinhardtii
+  JOURNAL   Unpublished
+REFERENCE   2  (bases 1 to 720)
+  AUTHORS   Boehm,C.R., Gorchs Rovira,A. and Mehrshahi,P.
+  TITLE     Direct Submission
+  JOURNAL   Submitted (16-JAN-2017) Plant Sciences, University of Cambridge,
+            Downing Street, Cambridge, Cambridgeshire CB2 3EA, United Kingdom
+COMMENT     ##Assembly-Data-START##
+            Sequencing Technology :: Sanger dideoxy sequencing
+            ##Assembly-Data-END##
+FEATURES             Location/Qualifiers
+     source          1..720
+                     /organism="synthetic construct"
+                     /mol_type="other DNA"
+                     /db_xref="taxon:32630"
+     gene            1..720
+                     /gene="cpmCerulean3"
+     CDS             1..720
+                     /gene="cpmCerulean3"
+                     /note="enhanced cyan fluorescent protein; codon-optimized
+                     for expression from the Chlamydomonas reinhardtii
+                     chloroplast"
+                     /codon_start=1
+                     /transl_table=11
+                     /product="mCerulean3"
+                     /protein_id="ATP07149.1"
+                     /translation="MVSKGEELFTGVVPILVELDGDVNGHKFSVSGEGEGDATYGKLTL
+                     KFICTTGKLPVPWPTLVTTLSWGVQCFARYPDHMKQHDFFKSAMPEGYVQERTIFFKDD
+                     GNYKTRAEVKFEGDTLVNRIELKGIDFKEDGNILGHKLEYNAIHGNVYITADKQKNGIK
+                     ANFGLNCNIEDGSVQLADHYQQNTPIGDGPVLLPDNHYLSTQSKLSKDPNEKRDHMVLL
+                     EFVTAAGITLGMDELYK"
+ORIGIN
+        1 atggtttcta aaggtgaaga attattcact ggtgttgtac caattttagt tgaattagat
+       61 ggtgacgtaa acggtcacaa attctcagta tcaggtgaag gtgaaggtga tgctacttac
+      121 ggtaaattaa ctttaaaatt catttgtaca acaggtaaat taccagttcc atggccaact
+      181 ttagtaacaa ctttatcttg gggtgtacaa tgtttcgctc gttacccaga tcacatgaaa
+      241 caacacgact tcttcaaatc agctatgcca gaaggttacg tacaagaacg tactattttc
+      301 ttcaaagatg atggtaacta caaaacacgt gctgaagtta aattcgaagg tgatacttta
+      361 gtaaaccgta ttgaattaaa aggtattgat ttcaaagaag atggtaacat tttaggtcac
+      421 aaattagaat acaacgctat tcacggtaac gtatacatta ctgctgataa acaaaaaaac
+      481 ggtattaaag ctaacttcgg tttaaactgt aacattgaag atggttcagt acaattagct
+      541 gatcactacc aacaaaacac tccaattggt gatggtccag ttttattacc agataaccac
+      601 tacttatcaa ctcaatctaa attatctaaa gatccaaacg aaaaacgtga ccacatggtt
+      661 ttattagaat tcgtaactgc tgctggtatt actttaggta tggatgaatt atacaaataa
+//

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -209,6 +209,15 @@ class TestGenBankSBOL3(unittest.TestCase):
         )
         self._test_round_trip_genbank(genbank_file)
     
+    def test_round_trip_structured_comments(self):
+        """Test ability to correctly round trip genbank test files in the iGEM distribution which have 
+        comment and structured comment annotations.
+        """
+        genbank_file = (
+            Path(__file__).parent / "test_files" / "sbol3_genbank_conversion" / "test_structured_comments.gb"
+        )
+        self._test_round_trip_genbank(genbank_file)
+    
     # def test_round_trip_all_iGEM(self):
     #     test_file_dir = Path(__file__).parent.parent / 'iGEM'
     #     for genbank_file in test_file_dir.glob('BBF10K_*.gb'):

--- a/test/test_genbank_sbol3_direct.py
+++ b/test/test_genbank_sbol3_direct.py
@@ -218,6 +218,15 @@ class TestGenBankSBOL3(unittest.TestCase):
         )
         self._test_round_trip_genbank(genbank_file)
     
+    def test_dblink_property(self):
+        """Test ability to correctly round trip genbank test files in the iGEM distribution which have 
+        the DB_LINK (or 'dbxrefs' in biopython) property.
+        """
+        genbank_file = (
+            Path(__file__).parent / "test_files" / "sbol3_genbank_conversion" / "test_dblink_property.gb"
+        )
+        self._test_round_trip_genbank(genbank_file)
+    
     # def test_round_trip_all_iGEM(self):
     #     test_file_dir = Path(__file__).parent.parent / 'iGEM'
     #     for genbank_file in test_file_dir.glob('BBF10K_*.gb'):


### PR DESCRIPTION
## Changes:
### Comment / Structured Comment Storage
* Certain iGEM test suite files had record annotations of "**comment**" (*text*) and "**structured_comment**" (*dictionary of dictionaries*).
* The class `CustomStructuredCommentProperty` is a *CustomTopLevel* extended class, to support setting and resetting of **structured_comment** in a round trip conversion of GenBank. It has a corresponding builder `build_custom_structured_comment_property` registered and invoked for parsing it while reading any SBOL3 file in the main `GenBank_SBOL3_Converter` class's `__init__()` call.
* The process of setting and resetting the **structured_comment** property is followed in a similar way to that followed for **FeatureQualifiers**. The inner dictionary's keys and values are stored in **TextListProperty** along with the index in which they occur in the original GenBank file - these key and value arrays are then sorted by this index before resetting them in GenBank files.
* Before the resetting of these **structured_comments**, a dictionary is created to link each SBOL3 component with the structured comments written under the corresponding sequence record in the original GenBank file. This has to be done as the `CustomStructuredCommentProperty` is a top-level class, and is not directly linked with each SBOL3 component.
* The **comment** text is stored in an added *TextProperty* of the extended component class `Component_GenBank_Extension`. It's setting and resetting is handled by the helper functions `_reset_extra_properties_in_genbank` and `_store_extra_properties_in_sbol3`.

### DB Links Storage
* Certain files had a list of texts for their "**dbxrefs**" properties on Sequence Records. Storage of these is implemented in a similar manner to **taxonomy**, where the list is stored as a string in the *genbank_dblink* property of the `Component_GenBank_Extension` class. Upon conversion to GenBank, the string is split into a list. This is again handled by the helper functions `_reset_extra_properties_in_genbank` and `_store_extra_properties_in_sbol3`.

### New test / test files
* New test file `test_structured_comments.gb` has been added to unit test the setting and resetting of structured comments in a round trip. This file is exactly the same as the `NCBI_GenBank_imports.gb` test file in the iGEM Test suite.

## TODO:

- [x]  A sample unit test needs to be added for files having comment / structured properties.
- [x]  A sample unit test needs to be added for files having DB Link properties.

Related to #166 