### PR TITLE
Add testing for Python 3.11

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         # Default builds are on Ubuntu
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         include:
           # Also test on macOS and Windows using the latest Python 3
           - os: macos-latest

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(name='sbol-utilities',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10'
+            'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11'
       ],
       # What does your project relate to?
       keywords='synthetic biology',


### PR DESCRIPTION
Python 3.11 was release in October, 2022. We are implicitly testing it with the Mac and Windows builds, but should also explicitly test it on Linux.