### PR TITLE
Improve documentation of calculate_complexity_scores.py utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The `sbol-calculate-sequences` utility attempts to calculate the sequence of any
 
 ### Calculate sequence synthesis complexity for DNA sequences in an SBOL file
 
-The `sbol-calculate-complexity-scores` utility attempts to calculate the synthesis complexity of any DNA sequence in the file, by sending sequences to be evaluated by IDT's sequence calculator service. Sequences whose complexity is known are not re-calculated. The system uses the gBlock API, which is intended for sequences from 125 to 3000 bp in length. If it is more than 3000 bp or less than 125 bp your returned score will be 0. A complexity score in the range from 0 to 10 means your sequence is synthesizable, if the score is greater or equal than 10 means it is not synthesizable.
+The `sbol-calculate-complexity` utility attempts to calculate the synthesis complexity of any DNA sequence in the file, by sending sequences to be evaluated by IDT's sequence calculator service. Sequences whose complexity is known are not re-calculated. 
+
+The system uses the gBlock API, which is intended for sequences from 125 to 3000 bp in length. If it is more than 3000 bp or less than 125 bp your returned score will be 0. A complexity score in the range from 0 to 10 means your sequence is synthesizable, if the score is greater or equal than 10 means it is not synthesizable.
 
 Note that use of this utility requires an account with IDT that is set up to use IDT's online service API (see: https://www.idtdna.com/pages/tools/apidoc)
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The `sbol-calculate-sequences` utility attempts to calculate the sequence of any
 
 ### Calculate sequence synthesis complexity for DNA sequences in an SBOL file
 
-The `sbol-calculate-sequences` utility attempts to calculate the synthesis complexity of any DNA sequence in the file, by sending sequences to be evaluated by IDT's sequence calculator service. Sequences whose complexity is know are not re-calculated.
+The `sbol-calculate-complexity-scores` utility attempts to calculate the synthesis complexity of any DNA sequence in the file, by sending sequences to be evaluated by IDT's sequence calculator service. Sequences whose complexity is known are not re-calculated. The system uses the gBlock API, which is intended for sequences from 125 to 3000 bp in length. If it is more than 3000 bp or less than 125 bp your returned score will be 0. A complexity score in the range from 0 to 10 means your sequence is synthesizable, if the score is greater or equal than 10 means it is not synthesizable.
 
 Note that use of this utility requires an account with IDT that is set up to use IDT's online service API (see: https://www.idtdna.com/pages/tools/apidoc)
 

--- a/sbol_utilities/calculate_complexity_scores.py
+++ b/sbol_utilities/calculate_complexity_scores.py
@@ -73,7 +73,9 @@ class IDTAccountAccessor:
 
     def get_sequence_scores(self, sequences: list[sbol3.Sequence]) -> list:
         """Retrieve synthesis complexity scores of sequences from the IDT API
-        This system uses the gBlock API, which is intended for sequences from 125 to 3000 bp in length
+        This system uses the gBlock API, which is intended for sequences from 125 to 3000 bp in length. If it is more 
+        than 3000 bp or less than 125 bp your returned score will be 0. A complexity score in the range from 0 to 10 means 
+        your sequence is synthesizable, if the score is greater or equal than 10 means it is not synthesizable.
 
         :param sequences: sequences for which we want to calculate the complexity score
         :return: dictionary mapping sequences to complexity Scores


### PR DESCRIPTION
Added the context of what the complexity score means in terms of synthesizability, in both the README and in the description of the function get_sequence_scores()