### PR TITLE
Round-trip of SBOL2/SBOL3 python conversion

### DIFF
--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -12,6 +12,8 @@ BACKPORT3_NAMESPACE = f'{BACKPORT_NAMESPACE}sbol3namespace'
 NON_EXTENSION_PROPERTY_PREFIXES = {sbol3.SBOL3_NS, sbol3.SBOL2_NS,  # SBOL 2 & 3 namespaces
                                    sbol3.RDF_NS, sbol3.PROV_NS, sbol3.OM_NS,  # Standard ontologies
                                    BACKPORT_NAMESPACE}  # Information added by this converter
+SBOL2_NON_EXTENSION_PROPERTY_PREFIXES = NON_EXTENSION_PROPERTY_PREFIXES.union({
+    'http://purl.org/dc/terms/description', 'http://purl.org/dc/terms/title'})
 
 
 class SBOL3To2ConversionVisitor:
@@ -57,9 +59,9 @@ class SBOL3To2ConversionVisitor:
             obj2.properties[p] = obj3._properties[p].copy()  # Can't use setPropertyValue because it may not be a string
 
     @staticmethod
-    def _value_or_property(obj3: sbol3.Identified, value, property: str):
-        if property in obj3._properties and len(obj3._properties[property]) == 1:
-            return value or obj3._properties[property][0]
+    def _value_or_property(obj3: sbol3.Identified, value, prop: str):
+        if prop in obj3._properties and len(obj3._properties[prop]) == 1:
+            return value or obj3._properties[prop][0]
         return value
 
     def _convert_identified(self, obj3: sbol3.Identified, obj2: sbol2.Identified):
@@ -306,7 +308,7 @@ class SBOL2To3ConversionVisitor:
     def _convert_extension_properties(obj2: sbol2.Identified, obj3: sbol3.Identified):
         """Copy over extension properties"""
         extension_properties = (p for p in obj2.properties
-                                if not any(p.startswith(prefix) for prefix in NON_EXTENSION_PROPERTY_PREFIXES))
+                                if not any(p.startswith(prefix) for prefix in SBOL2_NON_EXTENSION_PROPERTY_PREFIXES))
         for p in extension_properties:
             obj3._properties[p] = obj2.properties[p]
 

--- a/test/test_files/BBa_J23101_patched.nt
+++ b/test/test_files/BBa_J23101_patched.nt
@@ -9,7 +9,6 @@
 <https://synbiohub.org/public/igem/BBa_J23101> <http://sbols.org/v3#role> <http://identifiers.org/so/SO:0000167> .
 <https://synbiohub.org/public/igem/BBa_J23101> <http://sbols.org/v3#role> <http://wiki.synbiohub.org/wiki/Terms/igem#partType/Regulatory> .
 <https://synbiohub.org/public/igem/BBa_J23101> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000251> .
-<https://synbiohub.org/public/igem/BBa_J23101> <http://sboltools.org/backport#sbol2type> <http://sbols.org/v2#ComponentDefinition> .
 <https://synbiohub.org/public/igem/BBa_J23101> <http://sboltools.org/backport#sbol2version> "1" .
 <https://synbiohub.org/public/igem/BBa_J23101> <http://wiki.synbiohub.org/wiki/Terms/igem#discontinued> "false" .
 <https://synbiohub.org/public/igem/BBa_J23101> <http://wiki.synbiohub.org/wiki/Terms/igem#dominant> "true" .
@@ -47,7 +46,6 @@
 <https://synbiohub.org/public/igem/igem2sbol> <http://purl.org/dc/elements/1.1/creator> "James Alastair McLaughlin" .
 <https://synbiohub.org/public/igem/igem2sbol> <http://sbols.org/v3#description> "Conversion of the iGEM parts registry to SBOL2.1" .
 <https://synbiohub.org/public/igem/igem2sbol> <http://sbols.org/v3#name> "iGEM to SBOL conversion" .
-<https://synbiohub.org/public/igem/igem2sbol> <http://sbols.org/v2#persistentIdentity> <https://synbiohub.org/public/igem/igem2sbol> .
 <https://synbiohub.org/public/igem/igem2sbol> <http://sbols.org/v3#displayId> "igem2sbol" .
 <https://synbiohub.org/public/igem/igem2sbol> <http://sbols.org/v3#hasNamespace> <https://synbiohub.org> .
 <https://synbiohub.org/public/igem/igem2sbol> <http://sboltools.org/backport#sbol2version> "1" .
@@ -56,4 +54,4 @@
 <https://synbiohub.org/public/igem/igem2sbol> <http://wiki.synbiohub.org/wiki/Terms/synbiohub#topLevel> <https://synbiohub.org/public/igem/igem2sbol> .
 <https://synbiohub.org/public/igem/igem2sbol> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#TopLevel> .
 <https://synbiohub.org/public/igem/igem2sbol> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/prov#Activity> .
-<https://synbiohub.org/public/igem/igem2sbol> <http://www.w3.org/ns/prov#endedAtTime> "2017-03-06T15:00:00+00:00" .
+<https://synbiohub.org/public/igem/igem2sbol> <http://www.w3.org/ns/prov#endedAtTime> "2017-03-06T15:00:00+00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>  .

--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -22,15 +22,16 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
         doc3.read(TEST_FILES / 'BBa_J23101_patched.nt')
         # Convert to SBOL2 and check contents
         doc2 = convert3to2(doc3, True)
-        #self.assertEqual(len(doc2.validate()), 0)
+        #report = doc2.validate()
+        #self.assertEqual(len(report), 0, f'Validation failed: {report}')
         with tempfile.NamedTemporaryFile(suffix='.xml') as tmp2:
             doc2.write(tmp2.name)
             self.assertFalse(file_diff(tmp2.name, str(TEST_FILES / 'BBa_J23101.xml')))
-            doc3_loop = convert2to3(doc2)
-            #self.assertEqual(len(doc3_loop.validate()), 0)
+            doc3_loop = convert2to3(doc2, use_native_converter=True)
+            self.assertEqual(len(doc3_loop.validate()), 0)
             with tempfile.NamedTemporaryFile(suffix='.nt') as tmp3:
                 doc3_loop.write(tmp3.name)
-                #self.assertFalse(file_diff(tmp3.name, str(TEST_FILES / 'BBa_J23101_patched.nt')))
+                self.assertFalse(file_diff(tmp3.name, str(TEST_FILES / 'BBa_J23101_patched.nt')))
 
     def test_2to3_conversion(self):
         """Test ability to convert a simple part from SBOL3 to SBOL2"""
@@ -39,15 +40,16 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
         doc2.read(TEST_FILES / 'BBa_J23101.xml')
         # Convert to SBOL3 and check contents
         doc3 = convert2to3(doc2, use_native_converter=True)
-        #self.assertEqual(len(doc3.validate()), 0)
+        self.assertEqual(len(doc3.validate()), 0)
         with tempfile.NamedTemporaryFile(suffix='.nt') as tmp3:
             doc3.write(tmp3.name)
-            #self.assertFalse(file_diff(tmp3.name, str(TEST_FILES / 'BBa_J23101_patched.nt')))
-            doc2_loop = convert3to2(doc3)
-            # self.assertEqual(len(doc2_loop.validate()), 0)
+            self.assertFalse(file_diff(tmp3.name, str(TEST_FILES / 'BBa_J23101_patched.nt')))
+            doc2_loop = convert3to2(doc3, True)
+            # report = doc2.validate()
+            # self.assertEqual(len(report), 0, f'Validation failed: {report}')
             with tempfile.NamedTemporaryFile(suffix='.xml') as tmp2:
                 doc2_loop.write(tmp2.name)
-                #self.assertFalse(file_diff(tmp2.name, str(TEST_FILES / 'BBa_J23101.xml')))
+                self.assertFalse(file_diff(tmp2.name, str(TEST_FILES / 'BBa_J23101.xml')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Clean up minor details to allow triple-to-triple identity in first tests of SBOL2/SBOL3 Python conversion

Note that pySBOL2 validation fails, apparently due to an issue with SHACL rules for the DateTime type (https://github.com/SynBioDex/pySBOL2/issues/429)