### PR TITLE
Change Windows build to windows-2019

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,9 +23,9 @@ jobs:
         include:
           # Also test on macOS and Windows using the latest Python 3
           - os: macos-latest
-            python-version: 3.x
+            python-version: 3.11  # Return to 3.x after resolution of https://github.com/RDFLib/pySHACL/issues/212
           - os: windows-2019
-            python-version: 3.x
+            python-version: 3.11  # Return to 3.x after resolution of https://github.com/RDFLib/pySHACL/issues/212
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
           # Also test on macOS and Windows using the latest Python 3
           - os: macos-latest
             python-version: 3.x
-          - os: windows-latest
+          - os: windows-2019
             python-version: 3.x
 
     steps:


### PR DESCRIPTION
Biopython installation currently fails on the windows-2022 image (see https://github.com/biopython/biopython/issues/4463)

Until this is fixed, roll back to windows-2019, which is what biopython is tested against.