### PR TITLE
Implemented converstion of collection between SBOL2 and SBOL3 for the…

### DIFF
--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -129,9 +129,14 @@ class SBOL3To2ConversionVisitor:
         # Priority: 4
         raise NotImplementedError('Conversion of BinaryPrefix from SBOL3 to SBOL2 not yet implemented')
 
-    def visit_collection(self, a: sbol3.Collection):
+    def visit_collection(self, coll3: sbol3.Collection):
         # Priority: 1
-        raise NotImplementedError('Conversion of Collection from SBOL3 to SBOL2 not yet implemented')
+        # Make the Collection object and add it to the document
+        coll2 = sbol2.Collection(coll3.identity)
+        coll2.members = coll3.members
+        self.doc2.addCollection(coll2)
+        # Map over all other TopLevel properties and extensions not covered by the constructor
+        self._convert_toplevel(coll3, coll2)
 
     def visit_combinatorial_derivation(self, a: sbol3.CombinatorialDerivation):
         # Priority: 2
@@ -378,9 +383,13 @@ class SBOL2To3ConversionVisitor:
         # Priority: 2
         raise NotImplementedError('Conversion of Attachment from SBOL2 to SBOL3 not yet implemented')
 
-    def visit_collection(self, a: sbol2.Collection):
+    def visit_collection(self, coll2: sbol2.Collection):
         # Priority: 1
-        raise NotImplementedError('Conversion of Collection from SBOL2 to SBOL3 not yet implemented')
+        # Make the Collection object and add it to the document
+        coll3 = sbol3.Collection(coll2.identity, members=coll2.members)
+        self.doc3.add(coll3)
+        # Map over all other TopLevel properties and extensions not covered by the constructor
+        self._convert_toplevel(coll2, coll3)
 
     def visit_combinatorial_derivation(self, a: sbol2.CombinatorialDerivation):
         # Priority: 2

--- a/test/test_files/sbol3_collection.nt
+++ b/test/test_files/sbol3_collection.nt
@@ -1,0 +1,22 @@
+<https://sbolstandard.org/examples/col1> <http://sbols.org/v3#member> <https://sbolstandard.org/examples/LacI_protein> .
+<https://sbolstandard.org/examples/col1> <http://sbols.org/v3#member> <https://sbolstandard.org/examples/TetR_protein> .
+<https://sbolstandard.org/examples/col1> <http://sbols.org/v3#hasNamespace> <https://sbolstandard.org/examples> .
+<https://sbolstandard.org/examples/col1> <http://sbols.org/v3#displayId> "col1" .
+<https://sbolstandard.org/examples/col1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Collection> .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#role> <https://identifiers.org/GO:0003700> .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#description> "LacI protein" .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#name> "LacI" .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#hasNamespace> <https://sbolstandard.org/examples> .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000252> .
+<https://sbolstandard.org/examples/LacI_protein> <http://sbols.org/v3#displayId> "LacI_protein" .
+<https://sbolstandard.org/examples/LacI_protein> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#role> <https://identifiers.org/GO:0003700> .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#description> "TetR protein" .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#name> "TetR" .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#hasNamespace> <https://sbolstandard.org/examples> .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000252> .
+<https://sbolstandard.org/examples/TetR_protein> <http://sbols.org/v3#displayId> "TetR_protein" .
+<https://sbolstandard.org/examples/TetR_protein> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<https://sbolstandard.org/examples/TetR_protein> <http://sboltools.org/backport#sbol2version> "1" .
+<https://sbolstandard.org/examples/col1> <http://sboltools.org/backport#sbol2version> "1" .
+<https://sbolstandard.org/examples/LacI_protein> <http://sboltools.org/backport#sbol2version> "1" .

--- a/test/test_files/sbol_3to2_collection.xml
+++ b/test/test_files/sbol_3to2_collection.xml
@@ -1,0 +1,30 @@
+<rdf:RDF xmlns:brick="https://brickschema.org/schema/Brick#" xmlns:csvw="http://www.w3.org/ns/csvw#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcam="http://purl.org/dc/dcam/" xmlns:doap="http://usefulinc.com/ns/doap#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:odrl="http://www.w3.org/ns/odrl/2/" xmlns:org="http://www.w3.org/ns/org#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:qb="http://purl.org/linked-data/cube#" xmlns:schema="https://schema.org/" xmlns:sh="http://www.w3.org/ns/shacl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:sosa="http://www.w3.org/ns/sosa/" xmlns:ssn="http://www.w3.org/ns/ssn/" xmlns:time="http://www.w3.org/2006/time#" xmlns:vann="http://purl.org/vocab/vann/" xmlns:void="http://rdfs.org/ns/void#" xmlns:wgs="https://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:backport="http://sboltools.org/backport#" xmlns:om="http://www.ontology-of-units-of-measure.org/resource/om-2/" xmlns:sbol="http://sbols.org/v2#">
+  <sbol:Collection rdf:about="https://sbolstandard.org/examples/col1">
+    <sbol:member rdf:resource="https://sbolstandard.org/examples/LacI_protein"/>
+    <sbol:persistentIdentity rdf:resource="https://sbolstandard.org/examples/col1"/>
+    <sbol:displayId>col1</sbol:displayId>
+    <sbol:version>1</sbol:version>
+    <backport:sbol3namespace rdf:resource="https://sbolstandard.org/examples"/>
+    <sbol:member rdf:resource="https://sbolstandard.org/examples/TetR_protein"/>
+  </sbol:Collection>
+  <sbol:ComponentDefinition rdf:about="https://sbolstandard.org/examples/LacI_protein">
+    <sbol:role rdf:resource="https://identifiers.org/GO:0003700"/>
+    <dcterms:title>LacI</dcterms:title>
+    <sbol:persistentIdentity rdf:resource="https://sbolstandard.org/examples/LacI_protein"/>
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#Protein"/>
+    <dcterms:description>LacI protein</dcterms:description>
+    <backport:sbol3namespace rdf:resource="https://sbolstandard.org/examples"/>
+    <sbol:displayId>LacI_protein</sbol:displayId>
+    <sbol:version>1</sbol:version>
+  </sbol:ComponentDefinition>
+  <sbol:ComponentDefinition rdf:about="https://sbolstandard.org/examples/TetR_protein">
+    <sbol:type rdf:resource="http://www.biopax.org/release/biopax-level3.owl#Protein"/>
+    <sbol:displayId>TetR_protein</sbol:displayId>
+    <dcterms:title>TetR</dcterms:title>
+    <sbol:version>1</sbol:version>
+    <sbol:persistentIdentity rdf:resource="https://sbolstandard.org/examples/TetR_protein"/>
+    <backport:sbol3namespace rdf:resource="https://sbolstandard.org/examples"/>
+    <dcterms:description>TetR protein</dcterms:description>
+    <sbol:role rdf:resource="https://identifiers.org/GO:0003700"/>
+  </sbol:ComponentDefinition>
+</rdf:RDF>

--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -91,6 +91,44 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             doc2_loop.write(tmp2)
             self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'sbol_3to2_implementation.xml')))
 
+    def test_3to2_collection_conversion(self):
+        """Test ability to convert a collection from SBOL3 to SBOL2"""
+        # Load an SBOL3 document and check its contents
+        doc3 = sbol3.Document()
+        doc3.read(TEST_FILES / 'sbol3_collection.nt')
+        # Convert to SBOL2 and check contents
+        doc2 = convert3to2(doc3, True)
+        #report = doc2.validate()
+        #self.assertEqual(len(report), 0, f'Validation failed: {report}')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp2 = Path(tmpdir) / 'doc2.xml'
+            doc2.write(tmp2)
+            self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'sbol_3to2_collection.xml')))
+            doc3_loop = convert2to3(doc2, use_native_converter=True)
+            self.assertEqual(len(doc3_loop.validate()), 0)
+            tmp3 = Path(tmpdir) / 'doc3_loop.nt'
+            doc3_loop.write(tmp3)
+            self.assertFalse(file_diff(str(tmp3), str(TEST_FILES / 'sbol3_collection.nt')))
+
+    def test_2to3_collection_conversion(self):
+        """Test ability to convert a collection from SBOL2 to SBOL3"""
+        # Load an SBOL2 document and check its contents
+        doc2 = sbol2.Document()
+        doc2.read(TEST_FILES / 'sbol_3to2_collection.xml')
+        # Convert to SBOL3 and check contents
+        doc3 = convert2to3(doc2, use_native_converter=True)
+        self.assertEqual(len(doc3.validate()), 0)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp3 = Path(tmpdir) / 'doc3.nt'
+            doc3.write(tmp3)
+            self.assertFalse(file_diff(str(tmp3), str(TEST_FILES / 'sbol3_collection.nt')))
+            doc2_loop = convert3to2(doc3, True)
+            # report = doc2.validate()
+            # self.assertEqual(len(report), 0, f'Validation failed: {report}')
+            tmp2 = Path(tmpdir) / 'doc2_loop.xml'
+            doc2_loop.write(tmp2)
+            self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'sbol_3to2_collection.xml')))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In the new converter, I completed the `visit_collection` function for both the `SBOL3To2ConversionVisitor` and `SBOL2To3ConversionVisitor` classes. I also added two test cases to test my code using the SBOL3 [collection.nt](https://github.com/SynBioDex/SBOLTestSuite/blob/master/SBOL3/entity/collection/collection.nt) file from the [SBOLTestSuite](https://github.com/SynBioDex/SBOLTestSuite/tree/master).