### PR TITLE
Genbank features in translation list

### DIFF
--- a/sbol_utilities/conversion.py
+++ b/sbol_utilities/conversion.py
@@ -156,7 +156,7 @@ def convert2to3(sbol2_doc: Union[str, sbol2.Document], namespaces=None, use_nati
     # remap orientation types
     orientation_remapping = {
         sbol2.SBOL_ORIENTATION_INLINE: sbol3.SBOL_INLINE,
-        sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT: sbol3.SBOL_REVERSE_COMPLEMENT
+        sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT: sbol3.SO_REVERSE
     }
 
     def change_orientation(o):
@@ -207,7 +207,7 @@ def convert3to2(doc3: sbol3.Document, use_native_converter: bool = False) -> sbo
     # remap orientation types
     orientation_remapping = {
         sbol3.SBOL_INLINE: sbol2.SBOL_ORIENTATION_INLINE,
-        sbol3.SBOL_REVERSE_COMPLEMENT: sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT
+        sbol3.SO_REVERSE: sbol2.SBOL_ORIENTATION_REVERSE_COMPLEMENT
     }
 
     def change_orientation(o):

--- a/sbol_utilities/excel_to_sbol.py
+++ b/sbol_utilities/excel_to_sbol.py
@@ -248,7 +248,7 @@ def make_composite_component(display_id,part_lists,reverse_complements):
         if not len(part_list)==1:
             raise ValueError(f'Part list should have precisely one element, but is {part_list}')
         sub = sbol3.SubComponent(part_list[0])
-        sub.orientation = (sbol3.SBOL_REVERSE_COMPLEMENT if rc else sbol3.SBOL_INLINE)
+        sub.orientation = (sbol3.SO_REVERSE if rc else sbol3.SBOL_INLINE)
         composite_part.features.append(sub)
         if last_sub: composite_part.constraints.append(sbol3.Constraint(sbol3.SBOL_MEETS,last_sub,sub))
         last_sub = sub
@@ -303,7 +303,7 @@ def make_combinatorial_derivation(document, display_id,part_lists,reverse_comple
             sub = sbol3.SubComponent(part_list[0])
             template.features.append(sub)
         # in either case, orient and order the template elements
-        sub.orientation = (sbol3.SBOL_REVERSE_COMPLEMENT if rc else sbol3.SBOL_INLINE)
+        sub.orientation = (sbol3.SO_REVERSE if rc else sbol3.SBOL_INLINE)
         if template_part_list: template.constraints.append(sbol3.Constraint(sbol3.SBOL_MEETS,template_part_list[-1],sub))
         template_part_list.append(sub)
     # next, add all of the constraints to the template

--- a/sbol_utilities/gb2so.csv
+++ b/sbol_utilities/gb2so.csv
@@ -19,13 +19,14 @@ misc_binding,SO:0000409
 misc_difference,SO:0000413
 misc_feature,SO:0000001
 misc_marker,SO:0001645
-misc_recom,
-misc_RNA,SO:0000233
-misc_signal,SO:0001411
+misc_recomb,SO:0000298
+misc_RNA,SO:0000673
+misc_signal,SO:0005836
 misc_structure,SO:0000002
 modified_base,SO:0000305
 mRNA,SO:0000234
 N_region,SO:0001835
+old_sequence,SO:0000110
 polyA_signal,SO:0000551
 polyA_site,SO:0000553
 precursor_RNA,SO:0000185
@@ -44,7 +45,7 @@ satellite,SO:0000005
 scRNA,SO:0000013
 sig_peptide,SO:0000418
 snRNA,SO:0000274
-source,SO:0000149
+source,SO:2000061
 stem_loop,SO:0000313
 STS,SO:0000331
 TATA_signal,SO:0000174
@@ -53,7 +54,7 @@ transit_peptide,SO:0000725
 transposon,SO:0001054
 tRNA,SO:0000253
 V_region,SO:0001833
-variation,SO:0001060
+variation,SO:0000109
 -10_signal,SO:0000175
 -35_signal,SO:0000176
 3'clip,SO:0000557

--- a/sbol_utilities/sbol3_genbank_conversion.py
+++ b/sbol_utilities/sbol3_genbank_conversion.py
@@ -780,13 +780,13 @@ class GenBankSBOL3Converter:
                     feat_strand = self.BIO_STRAND_FORWARD
                     # feature strand value which denotes orientation of the location of the feature
                     # By default its 1 for SO_FORWARD orientation of sbol3 feature location, and -1 for SO_REVERSE
-                    if obj_feat_loc.orientation in {sbol3.SO_REVERSE, sbol3.SBOL_REVERSE_COMPLEMENT}:
+                    if obj_feat_loc.orientation in {sbol3.SO_REVERSE, sbol3.SO_REVERSE}:
                         feat_strand = self.BIO_STRAND_REVERSE
                     elif obj_feat_loc.orientation not in {sbol3.SO_FORWARD, sbol3.SBOL_INLINE}:
                         raise ValueError(f"Location orientation: `{obj_feat_loc.orientation}` for feature: \n \
                         `{obj_feat.name}` of component: `{obj.display_id}` is not a valid orientation.\n \
                         Valid orientations are `{sbol3.SO_FORWARD}`, `{sbol3.SO_REVERSE}`, `{sbol3.SBOL_INLINE}`, "
-                                         f"`{sbol3.SBOL_REVERSE_COMPLEMENT}`")
+                                         f"`{sbol3.SO_REVERSE}`")
                     # TODO: Raise custom converter class ERROR for `else:`
                     # creating start and end Positions
                     end_position = ExactPosition(obj_feat_loc.end)

--- a/sbol_utilities/so2gb.csv
+++ b/sbol_utilities/so2gb.csv
@@ -77,7 +77,6 @@ https://identifiers.org/SO:0000557,3'clip
 https://identifiers.org/SO:0000205,3'UTR
 https://identifiers.org/SO:0000555,5'clip
 https://identifiers.org/SO:0000204,5'UTR
-https://identifiers.org/SO:0000298,misc_recomb
 https://identifiers.org/SO:0000110,old_sequence
 https://identifiers.org/SO:0005836,misc_signal
 https://identifiers.org/SO:0000275,snoRNA

--- a/sbol_utilities/so2gb.csv
+++ b/sbol_utilities/so2gb.csv
@@ -54,7 +54,7 @@ https://identifiers.org/SO:0000005,satellite
 https://identifiers.org/SO:0000013,scRNA
 https://identifiers.org/SO:0000418,sig_peptide
 https://identifiers.org/SO:0000274,snRNA
-https://identifiers.org/SO:0000149,source
+https://identifiers.org/SO:2000061,source
 https://identifiers.org/SO:0002206,source
 https://identifiers.org/SO:0000019,stem_loop
 https://identifiers.org/SO:0000313,stem_loop
@@ -77,3 +77,13 @@ https://identifiers.org/SO:0000557,3'clip
 https://identifiers.org/SO:0000205,3'UTR
 https://identifiers.org/SO:0000555,5'clip
 https://identifiers.org/SO:0000204,5'UTR
+https://identifiers.org/SO:0000298,misc_recomb
+https://identifiers.org/SO:0000110,old_sequence
+https://identifiers.org/SO:0005836,misc_signal
+https://identifiers.org/SO:0000275,snoRNA
+https://identifiers.org/SO:0000730,gap
+https://identifiers.org/SO:0000470,J_segment
+https://identifiers.org/SO:0000470,J_gene_segment
+https://identifiers.org/SO:0001037,mobile_genetic_element
+https://identifiers.org/SO:0001086,sequence_uncertainty
+https://identifiers.org/SO:0000466,V_gene_segment


### PR DESCRIPTION
This is in response to issue #205.
Added the GenBank features which were not in the translation list. Also updated corresponding `SO` terms for some features according to [Sequence Ontology Mapping](http://www.sequenceontology.org/resources/mapping/FT_SO.html).

Also, there seem to be instances of the same feature with multiple `SO` terms in `so2gb.csv`. Do you want to keep all of them or only one unique `SO` term for each feature as given in `gb2so.csv` file?