### PR TITLE
Implement 'find_feature' Utility Function in SBOL Tutorial

### DIFF
--- a/sbol_utilities/helper_functions.py
+++ b/sbol_utilities/helper_functions.py
@@ -364,3 +364,17 @@ def is_circular(obj: Union[sbol3.Component, sbol3.LocalSubComponent, sbol3.Exter
     :return: true if circular
     """    
     return any(n==sbol3.SO_CIRCULAR for n in obj.types)
+def find_feature(doc: sbol3.Document, matching: Callable[[sbol3.Feature], bool]) -> Optional[sbol3.Feature]:
+    """
+    Search for a feature in the given SBOL document that matches the condition specified by the `matching` callable.
+    
+    :param doc: The SBOL document to search within.
+    :param matching: A callable that takes an sbol3.Feature as input and returns True if the feature matches the desired condition.
+    :return: The first sbol3.Feature that matches the condition, or None if no matching feature is found.
+    """
+    for obj in doc.objects:
+        if isinstance(obj, sbol3.Component):
+            for feature in obj.features:
+                if matching(feature):
+                    return feature
+    return None

--- a/sbol_utilities/helper_functions.py
+++ b/sbol_utilities/helper_functions.py
@@ -364,6 +364,8 @@ def is_circular(obj: Union[sbol3.Component, sbol3.LocalSubComponent, sbol3.Exter
     :return: true if circular
     """    
     return any(n==sbol3.SO_CIRCULAR for n in obj.types)
+
+
 def find_feature(doc: sbol3.Document, matching: Callable[[sbol3.Feature], bool]) -> Optional[sbol3.Feature]:
     """
     Search for a feature in the given SBOL document that matches the condition specified by the `matching` callable.


### PR DESCRIPTION
- **Implementation**: Introduced `find_feature` function to enhance feature search within SBOL documents, addressing issue #185.
- **Objective**: Simplifies the process of locating features that satisfy specific conditions, moving away from manual iteration to a more efficient, programmatic approach.
- **Advantages**:
  - Enhances code efficiency by reducing the need for verbose loop constructs.
  - Improves code readability, making it easier to understand and maintain.
  - Provides a flexible search mechanism through a callable parameter, allowing for diverse search criteria.
- **Technical Details**:
  - **Function Signature**: `find_feature(doc: sbol3.Document, matching: Callable[[sbol3.Feature], bool]) -> Optional[sbol3.Feature]`
  - Iterates through all `sbol3.Component` objects in the given `sbol3.Document`.
  - Applies the `matching` callable to each `sbol3.Feature` to determine if it meets the specified condition.
  - Returns the first matching `sbol3.Feature`, or `None` if no match is found.
- **Example Usage**:
  ```python
  found_feature = find_feature(doc, lambda feature: feature.instance_of == b0015.identity)
  if found_feature:
      # Demonstrates appending a new location to the found feature
      found_feature.locations.append(Range(i13504_seq, 746, 875))


closes #185 