### PR TITLE
Attempt to fix MacOS build failures (#232) by adjusting CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,9 +28,9 @@ jobs:
             python-version: 3.11  # Return to 3.x after resolution of https://github.com/RDFLib/pySHACL/issues/212
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -39,7 +39,11 @@ jobs:
         python -m pip install pytest
         python -m pip install interrogate
     - name: Setup Graphviz
-      uses: ts-graphviz/setup-graphviz@v1
+      uses: ts-graphviz/setup-graphviz@v2
+      with:
+        # Skip running of sometimes problematic brew update command on macOS.
+        # Remove after resolution of https://github.com/ts-graphviz/setup-graphviz/issues/593
+        macos-skip-brew-update: 'true' # default false
     - name: Show Node.js version
       run: |
         node --version


### PR DESCRIPTION
Attempt to fix MacOS build failures (#232) by adjusting CI workflow

The problem appears to be based on poor implementation of brew installation in the ts-graphviz/setup-graphviz script, which only halfway updates brew. There is a pending issue on https://github.com/ts-graphviz/setup-graphviz/issues/593
In the meantime, however, there is a known workaround in which one prohibits the system from attempting to update at all. That may not work forever, but is an acceptable intermediate point until the maintainers of ts-graphviz deal with the issue or are willing to accept a patch for the issue.

Fix was imported from working workflow in https://github.com/ModECI/MDF