### PR TITLE
Commented out tests with non-compliant files

### DIFF
--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -15,6 +15,9 @@ TEST_FILES = Path(__file__).parent / 'test_files'
 class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
 
     # TODO: turn on validation
+
+    # J23101.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
     def test_3to2_conversion(self):
         """Test ability to convert a simple part from SBOL3 to SBOL2"""
         # Load an SBOL3 document and check its contents
@@ -33,7 +36,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp3 = Path(tmpdir) / 'doc3_loop.nt'
             doc3_loop.write(tmp3)
             self.assertFalse(file_diff(str(tmp3), str(TEST_FILES / 'BBa_J23101_patched.nt')))
+    '''
 
+    # J23101.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
     def test_2to3_conversion(self):
         """Test ability to convert a simple part from SBOL2 to SBOL3"""
         # Load an SBOL2 document and check its contents
@@ -52,7 +58,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp2 = Path(tmpdir) / 'doc2_loop.xml'
             doc2_loop.write(tmp2)
             self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'BBa_J23101.xml')))
+    '''
 
+    # sbol_3to2_implementation.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
     def test_3to2_implementation_conversion(self):
         """Test ability to convert an implementation from SBOL3 to SBOL2"""
         # Load an SBOL3 document and check its contents
@@ -71,7 +80,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp3 = Path(tmpdir) / 'doc3_loop.nt'
             doc3_loop.write(tmp3)
             self.assertFalse(file_diff(str(tmp3), str(TEST_FILES / 'sbol3_implementation.nt')))
+    '''
 
+    # sbol_3to2_implementation.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
     def test_2to3_implementation_conversion(self):
         """Test ability to convert an implementation from SBOL2 to SBOL3"""
         # Load an SBOL2 document and check its contents
@@ -90,7 +102,11 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp2 = Path(tmpdir) / 'doc2_loop.xml'
             doc2_loop.write(tmp2)
             self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'sbol_3to2_implementation.xml')))
+    '''
 
+    # sbol_3to2_collection.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
+    # sbol_3to2_collection.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
     def test_3to2_collection_conversion(self):
         """Test ability to convert a collection from SBOL3 to SBOL2"""
         # Load an SBOL3 document and check its contents
@@ -109,7 +125,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp3 = Path(tmpdir) / 'doc3_loop.nt'
             doc3_loop.write(tmp3)
             self.assertFalse(file_diff(str(tmp3), str(TEST_FILES / 'sbol3_collection.nt')))
+    '''
 
+    # sbol_3to2_collection.xml is not SBOL compliant. Leaving conversions involving it for after the compliant converter is done
+    '''
     def test_2to3_collection_conversion(self):
         """Test ability to convert a collection from SBOL2 to SBOL3"""
         # Load an SBOL2 document and check its contents
@@ -128,7 +147,7 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
             tmp2 = Path(tmpdir) / 'doc2_loop.xml'
             doc2_loop.write(tmp2)
             self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'sbol_3to2_collection.xml')))
-
+    '''
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Since converter test files are not compliant (see issue #310) and there could be various reasons for non-compliance, I discussed with @PrashantVaidyanathan, @cjmyers and @jakebeal and found best to keep the files, but handle the conversion of them later.

For the efforts during Harmony 2025 we will only try to achieve conversions involving compliant SBOL2 files (taken from SBOL Test Suite or generated with pySBOL2)

Test files should be validated at https://validator.sbolstandard.org/ before being commited