### PR TITLE
 Refactor unittest.TestCase classes for the native converter

### DIFF
--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -12,13 +12,21 @@ from sbol_utilities.sbol_diff import file_diff
 TEST_FILES = Path(__file__).parent / 'test_files'
 
 
-class SBOLValidationError(Exception): pass
+class SBOLValidationError(Exception):
+    """This exception class is intended for use within the context of TestCases to raise failures due to invalid SBOL
+    documents."""
+    pass
 
 
-class SBOL2to3ConversionError(Exception): pass
+class SBOL2to3ConversionError(Exception):
+    """This exception class is intended for use within the context of TestCases to raise failures converting SBOL2
+    documents to SBOL3."""
+    pass
 
-
-class SBOL3to2ConversionError(Exception): pass
+class SBOL3to2ConversionError(Exception):
+    """This exception class is intended for use within the context of TestCases to raise failures converting SBOL3
+    documents to SBOL2."""
+    pass
 
 
 class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
@@ -254,10 +262,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
                 doc2_loop.write(tmp2)
                 self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'seq_componentDefinition.xml')))
 
-    def handle_2to3_conversion(self, test_filename, rubric_filename):
+    def handle_2to3_conversion(self, test_filename: str, comparison_filename: str):
         """Provides a re-usable test handler for converting SBOL2 to SBOL3 with different test files
-        test_filename: Name of an SBOL2 test file
-        rubric_filename: Name of an SBOL3 file with expected conversion
+        :param test_filename: Name of an SBOL2 test file
+        :param comparison_filename: Name of an SBOL3 file with expected conversion
     """
         """Test ability to convert a simple part from SBOL2 to SBOL3"""
 
@@ -274,7 +282,7 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp3 = Path(tmpdir) / 'doc3.nt'
             doc3.write(tmp3)
-            if file_diff(str(tmp3), str(TEST_FILES / rubric_filename)):
+            if file_diff(str(tmp3), str(TEST_FILES / comparison_filename)):
                 raise SBOL2to3ConversionError()
 
             # Round-trip back to SBOL2 and check contents
@@ -294,10 +302,10 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
 
 class TestDirectSBOL3SBOL2Conversion(unittest.TestCase):
 
-    def handle_3to2_conversion(self, test_filename, rubric_filename):
+    def handle_3to2_conversion(self, test_filename: str, comparison_filename: str):
         """Provides a re-usable test handler for converting SBOL3 to SBOL2 with different test files
-        test_filename: Name of an SBOL3 test file
-        rubric_filename: Name of an SBOL2 file with expected conversion
+        :param test_filename: Name of an SBOL3 test file
+        :param comparison_filename: Name of an SBOL2 file with expected conversion
     """
         # Load an SBOL3 document and check its contents
         doc3 = sbol3.Document()
@@ -312,7 +320,7 @@ class TestDirectSBOL3SBOL2Conversion(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp2 = Path(tmpdir) / 'doc2.xml'
             doc2.write(tmp2)
-            if file_diff(str(tmp2), str(TEST_FILES / rubric_filename)):
+            if file_diff(str(tmp2), str(TEST_FILES / comparison_filename)):
                 raise SBOL3to2ConversionError()
  
             # Round-trip back to SBOL3 and check contents

--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -12,6 +12,15 @@ from sbol_utilities.sbol_diff import file_diff
 TEST_FILES = Path(__file__).parent / 'test_files'
 
 
+class SBOLValidationError(Exception): pass
+
+
+class SBOL2to3ConversionError(Exception): pass
+
+
+class SBOL3to2ConversionError(Exception): pass
+
+
 class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
 
     # TODO: turn on validation
@@ -244,6 +253,82 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
                 tmp2 = Path(tmpdir) / 'doc2_loop.xml'
                 doc2_loop.write(tmp2)
                 self.assertFalse(file_diff(str(tmp2), str(TEST_FILES / 'seq_componentDefinition.xml')))
+
+    def handle_2to3_conversion(self, test_filename, rubric_filename):
+        """Provides a re-usable test handler for converting SBOL2 to SBOL3 with different test files
+        test_filename: Name of an SBOL2 test file
+        rubric_filename: Name of an SBOL3 file with expected conversion
+    """
+        """Test ability to convert a simple part from SBOL2 to SBOL3"""
+
+        # Load an SBOL2 document and check its contents
+        doc2 = sbol2.Document()
+        doc2.read(TEST_FILES / test_filename)
+
+        # Convert to SBOL3 and check contents
+        doc3 = convert2to3(doc2, use_native_converter=True)
+        report = doc3.validate()
+        if len(report):
+            raise SBOLValidationError(report)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp3 = Path(tmpdir) / 'doc3.nt'
+            doc3.write(tmp3)
+            if file_diff(str(tmp3), str(TEST_FILES / rubric_filename)):
+                raise SBOL2to3ConversionError()
+
+            # Round-trip back to SBOL2 and check contents
+            doc2_loop = convert3to2(doc3, True)
+            report = doc2_loop.validate()
+            if report != 'Valid.':
+                raise SBOLValidationError(report)
+
+            tmp2 = Path(tmpdir) / 'doc2_loop.xml'
+            doc2_loop.write(tmp2)
+            if file_diff(str(tmp2), str(TEST_FILES / test_filename)):
+                raise SBOL3to2ConversionError()
+
+    def test_implementation_conversion(self):
+        self.handle_2to3_conversion('sbol_3to2_implementation_compliant.xml', 'sbol_3to2_implementation_compliant.nt')
+
+
+class TestDirectSBOL3SBOL2Conversion(unittest.TestCase):
+
+    def handle_3to2_conversion(self, test_filename, rubric_filename):
+        """Provides a re-usable test handler for converting SBOL3 to SBOL2 with different test files
+        test_filename: Name of an SBOL3 test file
+        rubric_filename: Name of an SBOL2 file with expected conversion
+    """
+        # Load an SBOL3 document and check its contents
+        doc3 = sbol3.Document()
+        doc3.read(TEST_FILES / test_filename)
+
+        # Convert to SBOL2 and check contents
+        doc2 = convert3to2(doc3, True)
+        report = doc2.validate()
+        if report != 'Valid.':
+            raise SBOLValidationError(report)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp2 = Path(tmpdir) / 'doc2.xml'
+            doc2.write(tmp2)
+            if file_diff(str(tmp2), str(TEST_FILES / rubric_filename)):
+                raise SBOL3to2ConversionError()
+ 
+            # Round-trip back to SBOL3 and check contents
+            doc3_loop = convert2to3(doc2, use_native_converter=True)
+            report = doc3_loop.validate()
+            if len(report):
+                raise SBOLValidationError(report)
+
+            tmp3 = Path(tmpdir) / 'doc3_loop.nt'
+            doc3_loop.write(tmp3)
+            if file_diff(str(tmp3), str(TEST_FILES / test_filename)):
+                raise SBOL2to3ConversionError()
+
+    def test_implementation_conversion(self):
+        self.handle_3to2_conversion('sbol_3to2_implementation_compliant.nt', 'sbol_3to2_implementation_compliant.xml')
+
                 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The roundtrip tests for the native converter re-use a lot of the same code. Up til now, this code has been copy and pasted for each test case and has gotten crufty. So I factored out a more generalized method for handling conversion round trip tests.

Also introduced three specific Exception classes to make debugging test failures easier

This replaces #317 
