### PR TITLE
Feature/293 convert moduledefinition

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
           # Also test on macOS and Windows using the latest Python 3
           - os: macos-latest
             python-version: 3.x
-          - os: windows-2022
+          - os: windows-latest
             python-version: 3.x
 
     steps:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
           # Also test on macOS and Windows using the latest Python 3
           - os: macos-latest
             python-version: 3.x
-          - os: windows-2019
+          - os: windows-2022
             python-version: 3.x
 
     steps:

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -175,24 +175,36 @@ class SBOL3To2ConversionVisitor:
                     sbol3.SBO_SIMPLE_CHEMICAL: sbol2.BIOPAX_SMALL_MOLECULE,
                     sbol3.SBO_NON_COVALENT_COMPLEX: sbol2.BIOPAX_COMPLEX}
         types2 = [type_map.get(t, t) for t in cp3.types]
-        # Make the Component object and add it to the document
-        cp2 = sbol2.ComponentDefinition(self._sbol2_identity(cp3), types2, version=self._sbol2_version(cp3))
-        self.doc2.addComponentDefinition(cp2)
-        # Convert the Component properties not covered by the constructor
-        cp2.roles = cp3.roles
-        cp2.sequences = cp3.sequences
-        if cp3.features:
-            raise NotImplementedError('Conversion of Component features from SBOL3 to SBOL2 not yet implemented')
-        if cp3.interactions:
-            raise NotImplementedError('Conversion of Component interactions from SBOL3 to SBOL2 not yet implemented')
-        if cp3.constraints:
-            raise NotImplementedError('Conversion of Component constraints from SBOL3 to SBOL2 not yet implemented')
-        if cp3.interface:
-            raise NotImplementedError('Conversion of Component interface from SBOL3 to SBOL2 not yet implemented')
-        if cp3.models:
-            raise NotImplementedError('Conversion of Component models from SBOL3 to SBOL2 not yet implemented')
-        # Map over all other TopLevel properties and extensions not covered by the constructor
-        self._convert_toplevel(cp3, cp2)
+
+        # Determine whether Component maps to a ComponentDefinition or ModuleDefinition
+        if sbol3.SBO_FUNCTIONAL_ENTITY not in cp3.types:
+            # Make the Component object and add it to the document
+            cp2 = sbol2.ComponentDefinition(self._sbol2_identity(cp3), types2, version=self._sbol2_version(cp3))
+
+            # Convert the Component properties not covered by the constructor
+            cp2.roles = cp3.roles
+            cp2.sequences = cp3.sequences
+            for f in cp3.features:
+                raise NotImplementedError('Conversion of Component features from SBOL3 to SBOL2 not yet implemented')
+            if cp3.interactions:
+                raise NotImplementedError('Conversion of Component interactions from SBOL3 to SBOL2 not yet implemented')
+            if cp3.constraints:
+                raise NotImplementedError('Conversion of Component constraints from SBOL3 to SBOL2 not yet implemented')
+            if cp3.interface:
+                raise NotImplementedError('Conversion of Component interface from SBOL3 to SBOL2 not yet implemented')
+            if cp3.models:
+                raise NotImplementedError('Conversion of Component models from SBOL3 to SBOL2 not yet implemented')
+            self.doc2.addComponentDefinition(cp2)
+            self._convert_toplevel(cp3, cp2)
+        else:
+            # Component maps to an SBOL2 ModuleDefinition
+            mdef2 = sbol2.ModuleDefinition(self._sbol2_identity(cp3),
+                                           version=self._sbol2_version(cp3))
+            mdef2.roles = cp3.roles
+            mdef2.models = cp3.models
+            self.doc2.addComponentDefinition(mdef2)
+            self._convert_toplevel(cp3, mdef2)
+
 
     def visit_component_reference(self, a: sbol3.ComponentReference):
         # Priority: 3
@@ -584,8 +596,8 @@ class SBOL2To3ConversionVisitor:
         raise NotImplementedError('Conversion of Module from SBOL2 to SBOL3 not yet implemented')
 
     def visit_module_definition(self, md: sbol2.ModuleDefinition):
-        # Make the Component object and add it to the document
-        c3 = sbol3.Component(self._sbol3_identity(md), types=md.type, roles=md.roles, namespace=self._sbol3_namespace(md))
+        # ModuleDefinitions convert to SBOL3 Components annotated as "functional entities"
+        c3 = sbol3.Component(self._sbol3_identity(md), types=[sbol3.SBO_FUNCTIONAL_ENTITY], roles=md.roles, namespace=self._sbol3_namespace(md))
 
         for i2 in md.interactions:
             i3 = self.visit_interaction(i2)

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -617,6 +617,7 @@ class SBOL2To3ConversionVisitor:
                 if fc.direction == 'http://sbols.org/v2#none':
                     c3.interface.nondirectionals.append(sc)
         self.doc3.add(c3)
+        self._convert_toplevel(md, c3)
 
     def visit_participation(self, p2: sbol2.Participation):
         p3 = sbol3.Participation(p2.roles, strip_sbol2_version(p2.participant))

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -604,17 +604,18 @@ class SBOL2To3ConversionVisitor:
             c3.interactions.append(i3)
             self.update_identity(i2, i3)
 
-        c3.interface = sbol3.Interface()
-        for fc in md.functionalComponents:
-            sc = self.visit_functional_component(fc)
-            c3.features.append(sc)
-            self.update_identity(fc, sc)
-            if fc.direction == 'http://sbols.org/v2#in' or fc.direction == 'http://sbols.org/v2#inout':
-                c3.interface.inputs.append(sc)
-            if fc.direction == 'http://sbols.org/v2#out' or fc.direction == 'http://sbols.org/v2#inout':
-                c3.interface.outputs.append(sc)
-            if fc.direction == 'http://sbols.org/v2#none':
-                c3.interface.nondirectionals.append(sc)
+        if md.functionalComponents:
+            c3.interface = sbol3.Interface()
+            for fc in md.functionalComponents:
+                sc = self.visit_functional_component(fc)
+                c3.features.append(sc)
+                self.update_identity(fc, sc)
+                if fc.direction == 'http://sbols.org/v2#in' or fc.direction == 'http://sbols.org/v2#inout':
+                    c3.interface.inputs.append(sc)
+                if fc.direction == 'http://sbols.org/v2#out' or fc.direction == 'http://sbols.org/v2#inout':
+                    c3.interface.outputs.append(sc)
+                if fc.direction == 'http://sbols.org/v2#none':
+                    c3.interface.nondirectionals.append(sc)
         self.doc3.add(c3)
 
     def visit_participation(self, p2: sbol2.Participation):

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -203,7 +203,7 @@ class SBOL3To2ConversionVisitor:
             mdef2 = sbol2.ModuleDefinition(self._sbol2_identity(cp3),
                                            version=self._sbol2_version(cp3))
             mdef2.roles = cp3.roles
-            mdef2.models = cp3.models
+            mdef2.models = cp3.models  # TODO: post-fix up link, see #326
             self.doc2.addComponentDefinition(mdef2)
             self._convert_toplevel(cp3, mdef2)
 

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -177,6 +177,8 @@ class SBOL3To2ConversionVisitor:
         types2 = [type_map.get(t, t) for t in cp3.types]
 
         # Determine whether Component maps to a ComponentDefinition or ModuleDefinition
+        # TODO: An individual SBOL3 Component may actually map into SBOL2 as both a ComponentDefinition and a
+        # ModuleDefinition. Currently this method only converts to one or the other. See #246
         if sbol3.SBO_FUNCTIONAL_ENTITY not in cp3.types:
             # Make the Component object and add it to the document
             cp2 = sbol2.ComponentDefinition(self._sbol2_identity(cp3), types2, version=self._sbol2_version(cp3))

--- a/sbol_utilities/sbol3_sbol2_conversion.py
+++ b/sbol_utilities/sbol3_sbol2_conversion.py
@@ -602,22 +602,11 @@ class SBOL2To3ConversionVisitor:
         c3 = sbol3.Component(self._sbol3_identity(md), types=[sbol3.SBO_FUNCTIONAL_ENTITY], roles=md.roles, namespace=self._sbol3_namespace(md))
 
         for i2 in md.interactions:
-            i3 = self.visit_interaction(i2)
-            c3.interactions.append(i3)
-            self.update_identity(i2, i3)
+            raise NotImplementedError('Conversion of Interaction from SBOL2 to SBOL3 not yet implemented')
 
         if md.functionalComponents:
-            c3.interface = sbol3.Interface()
-            for fc in md.functionalComponents:
-                sc = self.visit_functional_component(fc)
-                c3.features.append(sc)
-                self.update_identity(fc, sc)
-                if fc.direction == 'http://sbols.org/v2#in' or fc.direction == 'http://sbols.org/v2#inout':
-                    c3.interface.inputs.append(sc)
-                if fc.direction == 'http://sbols.org/v2#out' or fc.direction == 'http://sbols.org/v2#inout':
-                    c3.interface.outputs.append(sc)
-                if fc.direction == 'http://sbols.org/v2#none':
-                    c3.interface.nondirectionals.append(sc)
+            raise NotImplementedError('Conversion of FunctionalComponent from SBOL2 to SBOL3 not yet implemented')
+
         self.doc3.add(c3)
         self._convert_toplevel(md, c3)
 

--- a/test/test_files/sbol_3to2_moduledefinition.nt
+++ b/test/test_files/sbol_3to2_moduledefinition.nt
@@ -1,0 +1,7 @@
+<http://synbiohub.bbn.com/1/md> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://sbols.org/v3#Component> .
+<http://synbiohub.bbn.com/1/md> <http://sbols.org/v3#description> "A simple ModuleDefinition" .
+<http://synbiohub.bbn.com/1/md> <http://sbols.org/v3#displayId> "md" .
+<http://synbiohub.bbn.com/1/md> <http://sbols.org/v3#hasNamespace> <http://synbiohub.bbn.com> .
+<http://synbiohub.bbn.com/1/md> <http://sboltools.org/backport#sbol2version> "1" .
+<http://synbiohub.bbn.com/1/md> <http://sbols.org/v3#role> <https://www.openmath.org/cd/logic1#nand> .
+<http://synbiohub.bbn.com/1/md> <http://sbols.org/v3#type> <https://identifiers.org/SBO:0000241> .

--- a/test/test_files/sbol_3to2_moduledefinition.xml
+++ b/test/test_files/sbol_3to2_moduledefinition.xml
@@ -1,0 +1,10 @@
+<rdf:RDF xmlns:brick="https://brickschema.org/schema/Brick#" xmlns:csvw="http://www.w3.org/ns/csvw#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcam="http://purl.org/dc/dcam/" xmlns:doap="http://usefulinc.com/ns/doap#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:geo="http://www.opengis.net/ont/geosparql#" xmlns:odrl="http://www.w3.org/ns/odrl/2/" xmlns:org="http://www.w3.org/ns/org#" xmlns:prof="http://www.w3.org/ns/dx/prof/" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:qb="http://purl.org/linked-data/cube#" xmlns:schema="https://schema.org/" xmlns:sh="http://www.w3.org/ns/shacl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:sosa="http://www.w3.org/ns/sosa/" xmlns:ssn="http://www.w3.org/ns/ssn/" xmlns:time="http://www.w3.org/2006/time#" xmlns:vann="http://purl.org/vocab/vann/" xmlns:void="http://rdfs.org/ns/void#" xmlns:wgs="https://www.w3.org/2003/01/geo/wgs84_pos#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#" xmlns:backport="http://sboltools.org/backport#" xmlns:sbol="http://sbols.org/v2#">
+  <sbol:ModuleDefinition rdf:about="http://synbiohub.bbn.com/md/1">
+    <sbol:role rdf:resource="https://www.openmath.org/cd/logic1#nand"/>
+    <backport:sbol3namespace rdf:resource="http://synbiohub.bbn.com"/>
+    <dcterms:description>A simple ModuleDefinition</dcterms:description>
+    <sbol:displayId>md</sbol:displayId>
+    <sbol:persistentIdentity rdf:resource="http://synbiohub.bbn.com/md"/>
+    <sbol:version>1</sbol:version>
+  </sbol:ModuleDefinition>
+</rdf:RDF>

--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -299,6 +299,9 @@ class TestDirectSBOL2SBOL3Conversion(unittest.TestCase):
     def test_implementation_conversion(self):
         self.handle_2to3_conversion('sbol_3to2_implementation_compliant.xml', 'sbol_3to2_implementation_compliant.nt')
 
+    def test_moduledefinition_conversion(self):
+        self.handle_2to3_conversion('sbol_3to2_moduledefinition.xml', 'sbol_3to2_moduledefinition.nt')
+
 
 class TestDirectSBOL3SBOL2Conversion(unittest.TestCase):
 

--- a/test/test_sbol2_sbol3_direct.py
+++ b/test/test_sbol2_sbol3_direct.py
@@ -340,6 +340,8 @@ class TestDirectSBOL3SBOL2Conversion(unittest.TestCase):
     def test_implementation_conversion(self):
         self.handle_3to2_conversion('sbol_3to2_implementation_compliant.nt', 'sbol_3to2_implementation_compliant.xml')
 
+    def test_moduledefinition_conversion(self):
+        self.handle_3to2_conversion('sbol_3to2_moduledefinition.nt', 'sbol_3to2_moduledefinition.xml')
                 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Roundtrip conversion of ModuleDefinition to Component and back again (#293 )

Current test case focuses on a simple ModuleDefinition.  Future PRs will expand test coverage to child classes, e.g., Interaction, FunctionalComponent, etc.

Test files were created synthetically using a pySBOL script (as opposed to representing an SBOL file found "in the wild").  Question: Do we want to check in this script? (It may be helpful for building out other representations to use as test cases).

While working on this, I noticed there's an annoying workaround that is required for our current round-trip tests to work.  In order for the triples in the original file to exactly match the triples in the round-tripped file, we have to artificially introduce a triple with `backport:sbol3namespace`  in the test file (see https://github.com/SynBioDex/SBOL-utilities/blob/8645fbe33b46173048dcfbb3300ff4bdfbaa8330/test/test_files/sbol_3to2_moduledefinition.xml#L4). 

(See https://github.com/SynBioDex/SBOL-utilities/issues/356 and https://github.com/SynBioDex/SBOL-utilities/issues/357)
